### PR TITLE
feat: Add a lock for Editors to only be able to use `/upload` in Staging area.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@
 .idea
 .vscode
 /slash-reloader-config.json
+
+# Bun Compiler Ignore
+bun.lock
+
 /config.json
 /lavalink-server.json
 /lavasfy-servers.json

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
     "version": "1.0.0",
     "description": "A bot made to help Solak Administration",
     "scripts": {
-        "build": "tsc --watch",
+        "build": "tsc -v",
+        "watch": "tsc --watch",
         "start": "ts-node --transpile-only index.ts",
         "start-js": "node ./dist/index.js"
     },

--- a/src/GuildSpecifics.ts
+++ b/src/GuildSpecifics.ts
@@ -7,7 +7,7 @@ interface Roles {
 }
 
 export function getChannels(guildId: string | undefined) : Channels {
-    let result = {}
+    let result = {} as Channels;
 
     //AGOD Bot Testing (Alex)
     if (guildId === '856557117832691752') {
@@ -104,14 +104,18 @@ export function getChannels(guildId: string | undefined) : Channels {
             learnerTempVCCreate: '1405678891565187112',
             learnerWaiting: '1405668159922503810',
             learnerTeaching: '1405338959063814227',
+            // Staging Guide Category
+            stagingEditorHub: '1389394110686953472',
+            // Prod Guide Category
+            editorHub: '1389410242210693212'
         }
     }
 
     return result;
 }
 
-export function getRoles(guildId: string | undefined) : Roles {
-    let result = {};
+export function getRoles(guildId: string | undefined, stripRole: boolean = false) : Roles {
+    let result = {} as Roles;
 
     //AGOD Bot Testing (Alex)
     if (guildId === '856557117832691752') {
@@ -303,8 +307,10 @@ export function getRoles(guildId: string | undefined) : Roles {
             enr500: '1401450408492404877',
             enr1000: '1401450459256066141',
             enr2000: '1401450500481749062',
+            // Editor Roles
+            editor: '1389397640533250058'           
         }
     }
 
-    return Object.fromEntries(Object.entries(result).map(([key, value]) => [key, `<@&${value}>`]));
+    return Object.fromEntries(Object.entries(result).map(([key, value]) => [key, stripRole ? value : `<@&${value}>`]));
 }

--- a/src/entity/Warning.ts
+++ b/src/entity/Warning.ts
@@ -16,5 +16,8 @@ export class Warning {
     issuedBy: string
 
     @CreateDateColumn({ name: 'created_at'})
-    createdAt: Date;
+    createdAt: Date
+
+    @Column({ nullable: true })
+    reportRef?: string;
 }

--- a/src/interactions/info/Upload.ts
+++ b/src/interactions/info/Upload.ts
@@ -1,9 +1,9 @@
 import BotInteraction from '../../types/BotInteraction';
-import { Attachment, ChatInputCommandInteraction, EmbedBuilder, SlashCommandBuilder, TextChannel, ChannelType, Message, MessageFlags } from 'discord.js';
+import { Attachment, ChatInputCommandInteraction, EmbedBuilder, SlashCommandBuilder, TextChannel, ChannelType, Message, MessageFlags, GuildMember, Role } from 'discord.js';
 import { parseTree, getNodeValue, ParseError, findNodeAtOffset, Node } from 'jsonc-parser';
 import * as fs from 'fs/promises';
 import * as path from 'path';
-import { getChannels } from '../../GuildSpecifics';
+import { getChannels, getRoles } from '../../GuildSpecifics';
 
 type ParsedMessage = {
     content: string;
@@ -78,12 +78,28 @@ export default class Upload extends BotInteraction {
             );
     }
 
-    async run(interaction: ChatInputCommandInteraction) {
+    async run(interaction: ChatInputCommandInteraction<'cached'>) {
         await interaction.deferReply({ flags: MessageFlags.Ephemeral });
-
+        const member: GuildMember = await interaction.member.fetch(true);
+        const roles = getRoles(interaction.guild?.id, true);
+        const memberEditorRole = member.roles.cache.get(roles?.editor);
+        const isAdmin = member.roles.cache.some(role => role.id === roles.owner || role.id === roles.admin);
+        const stagingCategory: string = getChannels(interaction.guild?.id)?.stagingEditorHub!;
         const attachment: Attachment | null = interaction.options.getAttachment('file', true);
         const targetChannel = (interaction.options.getChannel('channel', false) || interaction.channel) as TextChannel;
 
+        // check if the channel has a parent, if not then crash :)
+        const parentCategory: string | null = targetChannel.parentId;
+        if (!parentCategory) {
+            return await interaction.editReply({ content: 'The channel you selected has no parent category.' })
+        }
+
+        // Check if the user has the editor role in the guild.
+        if (!memberEditorRole && !isAdmin) {
+            return await interaction.editReply({ content: 'You do not have permission to use this command.' })
+        }
+
+        // -- START check attachments --
         if (!attachment) {
             return await interaction.editReply({ content: 'No file was provided.' });
         }
@@ -104,6 +120,17 @@ export default class Upload extends BotInteraction {
             return await interaction.editReply({
                 content: 'File is too large. Please upload a file smaller than 5MB.'
             });
+        }
+        // -- END check attachments --
+
+        // The editor role can only use /upload to the staging guide category
+        if (!isAdmin && parentCategory === stagingCategory && !memberEditorRole) {
+            return await interaction.editReply({ content: 'sit lmao' })
+        }
+
+        // If the category is not the staging area and the user has the editor role
+        if (parentCategory !== stagingCategory && memberEditorRole) {
+            return await interaction.editReply({ content: 'You do not have permissions to post guides here.' })
         }
 
         try {

--- a/src/interactions/info/Upload.ts
+++ b/src/interactions/info/Upload.ts
@@ -129,7 +129,7 @@ export default class Upload extends BotInteraction {
         }
 
         // If the category is not the staging area and the user has the editor role
-        if (parentCategory !== stagingCategory && memberEditorRole) {
+        if (!isAdmin && parentCategory !== stagingCategory && memberEditorRole) {
             return await interaction.editReply({ content: 'You do not have permissions to post guides here.' })
         }
 

--- a/src/interactions/info/Upload.ts
+++ b/src/interactions/info/Upload.ts
@@ -56,7 +56,7 @@ export default class Upload extends BotInteraction {
     }
 
     get permissions() {
-        return 'ELEVATED_ROLE';
+        return 'EDITOR';
     }
 
     get slashData() {
@@ -123,12 +123,11 @@ export default class Upload extends BotInteraction {
         }
         // -- END check attachments --
 
-        // The editor role can only use /upload to the staging guide category
+        // (bypass for admins)The editor role can only use /upload to the staging guide category
         if (!isAdmin && parentCategory === stagingCategory && !memberEditorRole) {
-            return await interaction.editReply({ content: 'sit lmao' })
+            return await interaction.editReply({ content: 'You do not have permissions to post guides here.' })
         }
 
-        // If the category is not the staging area and the user has the editor role
         if (!isAdmin && parentCategory !== stagingCategory && memberEditorRole) {
             return await interaction.editReply({ content: 'You do not have permissions to post guides here.' })
         }

--- a/src/interactions/info/Upload.ts
+++ b/src/interactions/info/Upload.ts
@@ -243,11 +243,7 @@ export default class Upload extends BotInteraction {
                         tagToUrlMap.set(part.nameTag, sentMessage.url);
                     }
 
-                    // Always pin messages that contain Table of Contents
-                    const hasTableOfContents = finalEmbeds.some(embed => embed.title && embed.title.toLowerCase().includes('table of contents'))
-                                                || components.some(comps => comps.components.some((component: any) => component.type === 10 && component.content.toLowerCase().includes('table of contents')));
-
-                    if (hasTableOfContents) {
+                    if (part.pinAndDeleteOld) {
                         try {
                             await sentMessage.pin();
                             this.client.logger.log({ message: `Successfully pinned Table of Contents message ${sentMessage.id}` }, true);

--- a/src/interactions/moderation/Warn.ts
+++ b/src/interactions/moderation/Warn.ts
@@ -3,6 +3,7 @@ import { Warning } from '../../entity/Warning';
 import { getChannels } from '../../GuildSpecifics';
 import BotInteraction from '../../types/BotInteraction';
 import { ChatInputCommandInteraction, MessageFlags, SlashCommandBuilder, User } from 'discord.js';
+import UtilityHandler from '../../modules/UtilityHandler';
 
 export default class Warn extends BotInteraction {
     get name() {
@@ -140,13 +141,13 @@ export default class Warn extends BotInteraction {
                     let content: string = '';
 
                     if (id) {
-                        content = `Found warning for ID \`${id}\`:\n`
+                        content = `Found warning for ID \`${id}\`:\n\n`
                     } else if (user) {
                         content = `Found warnings for User <@${user.id}>:\n\n`
                     } else if (reportRef) {
-                        content = `Found warnings for Report reference \`${reportRef}\`:\n`
+                        content = `Found warnings for report reference \`${reportRef}\`:\n\n`
                     } else {
-                        content = `Found warnings:\n`
+                        content = `Found warnings:\n\n`
                     }
 
                     for (const warning of foundWarnings) {
@@ -157,10 +158,13 @@ export default class Warn extends BotInteraction {
                             content += `**Reason:** \`${warning.reason}\`\n`;
                             content += `**Report reference:** \`${warning.reportRef}\`\n\n`;
                         } else {
-                            content += `**ID:** \`${warning.id}\`, **User:** <@${warning.user}>, **Reason:** \`${warning.reason}\`, **Report reference:** \`${warning.reportRef}\`\n`;
+                            content += `**ID:** \`${warning.id}\`\n`;
+                            content += `**User:** <@${warning.user}>\n`;
+                            content += `**Reason:** \`${warning.reason}\`\n`;
+                            content += `**Report reference:** \`${warning.reportRef}\`\n\n`;
                         }
                     }
-
+                    
                     content = content.trim();
 
                     response.addTextDisplayComponents(builder => builder.setContent(content));

--- a/src/interactions/moderation/Warn.ts
+++ b/src/interactions/moderation/Warn.ts
@@ -1,3 +1,4 @@
+import { report } from 'process';
 import { Warning } from '../../entity/Warning';
 import { getChannels } from '../../GuildSpecifics';
 import BotInteraction from '../../types/BotInteraction';
@@ -36,6 +37,7 @@ export default class Warn extends BotInteraction {
             .addNumberOption((option) => option.setName('action').setDescription('Action').addChoices([...this.actionOptions]).setRequired(true))
             .addUserOption((option) => option.setName('user').setDescription('User').setRequired(false))
             .addStringOption((option) => option.setName('reason').setDescription('Reason of the warning').setRequired(false))
+            .addStringOption((option) => option.setName('reportref').setDescription('Any ticket reference').setRequired(false))
             .addNumberOption((option) => option.setName('id').setDescription('Id of the warning (when removing)').setRequired(false));
     }
 
@@ -52,6 +54,7 @@ export default class Warn extends BotInteraction {
         const action: number = interaction.options.getNumber('action', true);
         const user: User | null = interaction.options.getUser('user', false);
         const reason: string | null = interaction.options.getString('reason', false);
+        const reportRef: string | null = interaction.options.getString('reportref', false);
         const id: number | null = interaction.options.getNumber('id', false);
 
         const { dataSource } = this.client;
@@ -61,11 +64,14 @@ export default class Warn extends BotInteraction {
             case 0:
                 // Add warning
                 if (user && reason) {
-                    const newWarning: Warning = repository.create({
+                    const warningData: Partial<Warning> = {
                         user: user.id,
                         reason: reason,
-                        issuedBy: interaction.user.id
-                    });
+                        issuedBy: interaction.user.id,
+                    };
+                    if (reportRef) warningData.reportRef = reportRef;
+
+                    const newWarning: Warning = repository.create(warningData);
 
                     const savedWarning: Warning = await repository.save(newWarning);
 
@@ -123,6 +129,11 @@ export default class Warn extends BotInteraction {
                     filters += `\n- **User:** <@${user.id}>`;
                 }
 
+                if (reportRef) {
+                    foundWarnings = foundWarnings.filter(x => x.user === reportRef);
+                    filters += `\n- **Report reference:** <@${reportRef}>`;
+                }
+
                 if (foundWarnings.length > 0 && foundWarnings.length < 50) {
                     const response = this.client.util.getContainerBuilder(null, `List warnings - \`${foundWarnings.length}\` found`);
 
@@ -131,7 +142,9 @@ export default class Warn extends BotInteraction {
                     if (id) {
                         content = `Found warning for ID \`${id}\`:\n`
                     } else if (user) {
-                        content = `Found warnings for User <@${user.id}>:\n`
+                        content = `Found warnings for User <@${user.id}>:\n\n`
+                    } else if (reportRef) {
+                        content = `Found warnings for Report reference <@${reportRef}>:\n`
                     } else {
                         content = `Found warnings:\n`
                     }
@@ -140,9 +153,11 @@ export default class Warn extends BotInteraction {
                         if (id) {
                             content += `**User:** <@${warning.user}>\n**Reason:** \`${warning.reason}\``;
                         } else if (user) {
-                            content += `**ID:** \`${warning.id}\`, **Reason:** \`${warning.reason}\`\n`;
+                            content += `**ID:** \`${warning.id}\`\n`;
+                            content += `**Reason:** \`${warning.reason}\`\n`;
+                            content += `**Report reference:** \`${warning.reportRef}\`\n\n`;
                         } else {
-                            content += `**ID:** \`${warning.id}\`, **User:** <@${warning.user}>, **Reason:** \`${warning.reason}\`\n`;
+                            content += `**ID:** \`${warning.id}\`, **User:** <@${warning.user}>, **Reason:** \`${warning.reason}, **Report reference**: ${warning.reportRef}\`\n`;
                         }
                     }
 
@@ -153,7 +168,7 @@ export default class Warn extends BotInteraction {
                     return await interaction.editReply({ components: [response], flags: MessageFlags.IsComponentsV2, allowedMentions: { "parse": [] } });
                 } else if (foundWarnings.length >= 50) {
                     const response = this.client.util.getContainerBuilder(false, 'List warnings')
-                        .addTextDisplayComponents(builder => builder.setContent(`Found to many warnings (\`${foundWarnings.length}\`), please specify your search until a proper pagination system is implemented.`));
+                        .addTextDisplayComponents(builder => builder.setContent(`Found too many warnings (\`${foundWarnings.length}\`), please specify your search until a proper pagination system is implemented.`));
                     return await interaction.editReply({ components: [response], flags: MessageFlags.IsComponentsV2 });
                 } else {
                     const response = this.client.util.getContainerBuilder(false, 'List warnings')

--- a/src/interactions/moderation/Warn.ts
+++ b/src/interactions/moderation/Warn.ts
@@ -130,8 +130,8 @@ export default class Warn extends BotInteraction {
                 }
 
                 if (reportRef) {
-                    foundWarnings = foundWarnings.filter(x => x.user === reportRef);
-                    filters += `\n- **Report reference:** <@${reportRef}>`;
+                    foundWarnings = foundWarnings.filter(x => x.reportRef === reportRef);
+                    filters += `\n- **Report reference:** \`${reportRef}\``;
                 }
 
                 if (foundWarnings.length > 0 && foundWarnings.length < 50) {
@@ -144,7 +144,7 @@ export default class Warn extends BotInteraction {
                     } else if (user) {
                         content = `Found warnings for User <@${user.id}>:\n\n`
                     } else if (reportRef) {
-                        content = `Found warnings for Report reference <@${reportRef}>:\n`
+                        content = `Found warnings for Report reference \`${reportRef}\`:\n`
                     } else {
                         content = `Found warnings:\n`
                     }
@@ -157,7 +157,7 @@ export default class Warn extends BotInteraction {
                             content += `**Reason:** \`${warning.reason}\`\n`;
                             content += `**Report reference:** \`${warning.reportRef}\`\n\n`;
                         } else {
-                            content += `**ID:** \`${warning.id}\`, **User:** <@${warning.user}>, **Reason:** \`${warning.reason}, **Report reference**: ${warning.reportRef}\`\n`;
+                            content += `**ID:** \`${warning.id}\`, **User:** <@${warning.user}>, **Reason:** \`${warning.reason}\`, **Report reference:** \`${warning.reportRef}\`\n`;
                         }
                     }
 

--- a/src/modules/InteractionHandler.ts
+++ b/src/modules/InteractionHandler.ts
@@ -188,6 +188,15 @@ export default class InteractionHandler extends EventEmitter {
                             return await interaction.reply({ content: 'You do not have permissions to run this command. This incident has been logged.', ephemeral: true });
                         }
                         break;
+                    case 'EDITOR':
+                        if (!(await this.client.util.hasRolePermissions(this.client, ['editor', 'admin', 'owner'], interaction))) {
+                            this.client.logger.log({
+                                message: `Attempted restricted permissions. { command: ${command.name}, user: ${interaction.user.username}, channel: ${interaction.channel} }`,
+                                handler: this.constructor.name,
+                            }, true);
+                            return await interaction.reply({ content: 'You do not have permissions to run this command. This incident has been logged.', ephemeral: true });
+                        }
+                        break;
                     case 'TRIAL_TEAM_AND_TEACHER':
                         if (!(await this.client.util.hasRolePermissions(this.client, ['teacher', 'trialTeam', 'admin', 'owner'], interaction))) {
                             this.client.logger.log({


### PR DESCRIPTION
- Admins + Owners can bypass
- Editors are not allowed to post outside of the IDs added to
- Pulled in latest changes

https://github.com/Amascut-Bot/Amascut-discord-bot/compare/production...txj-xyz:development?expand=1#diff-17ab91381c0e9900526c5d247c1f16053c16166bdd29b7b0564af52e6ce3435bR108