### PR TITLE
Improvements on /warn, /download, /upload

### DIFF
--- a/src/interactions/info/Download.ts
+++ b/src/interactions/info/Download.ts
@@ -67,7 +67,7 @@ export default class Download extends BotInteraction {
 
                 // Send log message
                 try {
-                    const logChannelId = interaction.channelId;
+                    const logChannelId = getChannels(interaction.guild?.id).uploadLogChannel;
                     const logChannel = await this.client.channels.fetch(logChannelId);
                     if (logChannel instanceof TextChannel) {
                         // Create a new attachment to be sent to the log channel
@@ -88,7 +88,7 @@ export default class Download extends BotInteraction {
                 }
 
                 return await interaction.editReply({
-                    content: `Here is the archive of the last uplaod from <#${channel.id}>.`,
+                    content: `Here is the archive of the last upload from <#${channel.id}>.`,
                     files: [attachment],
                 });
             }

--- a/src/interactions/info/Download.ts
+++ b/src/interactions/info/Download.ts
@@ -54,7 +54,7 @@ export default class Download extends BotInteraction {
             //try to find an archived file first, if no one to be found, download the channel
             const archiveDir = path.join(process.cwd(), 'upload_archives');
             //2025-07-14T21-37-50.955Z_test-channel_role-assign-archive3
-            const pattern = new RegExp(channel.name);
+            const pattern = new RegExp(channel.id);
 
             const archivedFile = await this.getNewestFile(archiveDir, pattern);
 
@@ -174,7 +174,7 @@ export default class Download extends BotInteraction {
             const fileContent = messageBlocks.join('\n.\n');
 
             const attachment = new AttachmentBuilder(Buffer.from(fileContent, 'utf-8'), {
-                name: `${channel.name}-archive.txt`,
+                name: `${channel.name}-download.txt`,
             });
 
             // Send log message
@@ -184,7 +184,7 @@ export default class Download extends BotInteraction {
                 if (logChannel instanceof TextChannel) {
                     // Create a new attachment to be sent to the log channel
                     const logAttachment = new AttachmentBuilder(Buffer.from(fileContent, 'utf-8'), {
-                        name: `${channel.name}-archive.txt`,
+                        name: `${channel.name}-download.txt`,
                     });
                     await logChannel.send({
                         content: `${interaction.user.username} downloaded from <#${channel.id}>`,
@@ -200,7 +200,7 @@ export default class Download extends BotInteraction {
             }
 
             await interaction.editReply({
-                content: `Here is the archive of the last ${reversedMessages.length} messages from <#${channel.id}>.`,
+                content: `Here is the download of the last ${reversedMessages.length} messages from <#${channel.id}>.`,
                 files: [attachment],
             });
 

--- a/src/interactions/info/Upload.ts
+++ b/src/interactions/info/Upload.ts
@@ -110,7 +110,7 @@ export default class Upload extends BotInteraction {
             });
         }
 
-        if (!attachment.name?.endsWith('.txt') && attachment.contentType !== 'text/plain') {
+        if (!attachment.name?.endsWith('.txt') || attachment.contentType !== 'text/plain') {
             return await interaction.editReply({
                 content: 'Please upload a valid text file (.txt).'
             });
@@ -149,7 +149,7 @@ export default class Upload extends BotInteraction {
                 const archiveDir = path.join(process.cwd(), 'upload_archives');
                 await fs.mkdir(archiveDir, { recursive: true });
                 const timestamp = new Date().toISOString().replace(/:/g, '-');
-                const archiveFileName = `${timestamp}_${targetChannel.name}_${attachment.name}`;
+                const archiveFileName = `${timestamp}_${targetChannel.id}.txt`;
                 const archiveFilePath = path.join(archiveDir, archiveFileName);
                 await fs.writeFile(archiveFilePath, fileContent);
             } catch (archiveError) {

--- a/src/interactions/moderation/Warn.ts
+++ b/src/interactions/moderation/Warn.ts
@@ -2,7 +2,7 @@ import { report } from 'process';
 import { Warning } from '../../entity/Warning';
 import { getChannels } from '../../GuildSpecifics';
 import BotInteraction from '../../types/BotInteraction';
-import { ChatInputCommandInteraction, MessageFlags, SlashCommandBuilder, TextChannel, User } from 'discord.js';
+import { ChannelType, ChatInputCommandInteraction, MessageFlags, SlashCommandBuilder, TextChannel, User } from 'discord.js';
 import UtilityHandler from '../../modules/UtilityHandler';
 
 export default class Warn extends BotInteraction {
@@ -23,6 +23,7 @@ export default class Warn extends BotInteraction {
             'Add': 0,
             'Remove': 1,
             'List': 2,
+            'Update': 3
         }
         const options: any = [];
         Object.keys(ticketTypes).forEach((key: string) => {
@@ -38,7 +39,7 @@ export default class Warn extends BotInteraction {
             .addNumberOption((option) => option.setName('action').setDescription('Action').addChoices([...this.actionOptions]).setRequired(true))
             .addUserOption((option) => option.setName('user').setDescription('User').setRequired(false))
             .addStringOption((option) => option.setName('reason').setDescription('Reason of the warning').setRequired(false))
-            .addChannelOption((option) => option.setName('reportref').setDescription('Any ticket reference').setRequired(false))
+            .addChannelOption((option) => option.setName('reportref').setDescription('Any ticket reference').setRequired(false).addChannelTypes(ChannelType.PublicThread, ChannelType.PrivateThread))
             .addNumberOption((option) => option.setName('id').setDescription('Id of the warning (when removing)').setRequired(false));
     }
 
@@ -156,17 +157,20 @@ export default class Warn extends BotInteraction {
 
                     for (const warning of foundWarnings) {
                         if (id) {
-                            content += `**User:** <@${warning.user}>\n**Reason:** \`${warning.reason}\``;
+                            content += `**User:** <@${warning.user}>\n`
+                            content += `**Reason:** \`${warning.reason}\`\n`;
+                            if (warning.reportRef) content += `**Report reference:** <#${warning.reportRef}>\n`;
                         } else if (user) {
                             content += `**ID:** \`${warning.id}\`\n`;
                             content += `**Reason:** \`${warning.reason}\`\n`;
-                            content += `**Report reference:** <#${warning.reportRef}>\n\n`;
+                            if (warning.reportRef) content += `**Report reference:** <#${warning.reportRef}>\n`;
                         } else {
                             content += `**ID:** \`${warning.id}\`\n`;
                             content += `**User:** <@${warning.user}>\n`;
                             content += `**Reason:** \`${warning.reason}\`\n`;
-                            content += `**Report reference:** <#${warning.reportRef}>\n\n`;
+                            if (warning.reportRef) content += `**Report reference:** <#${warning.reportRef}>\n`;
                         }
+                        content += '\n';
                     }
 
                     content = content.trim();
@@ -184,6 +188,34 @@ export default class Warn extends BotInteraction {
                     return await interaction.editReply({ components: [response], flags: MessageFlags.IsComponentsV2 });
                 }
 
+            case 3:
+                if (id) {
+                    const foundWarning: Warning | null = await repository.findOne({
+                        where: {
+                            id: id
+                        }
+                    });
+
+                    if (foundWarning) {
+                        if (user) foundWarning.user = user.id;
+                        if (reportRef) foundWarning.reportRef = reportRef.id;
+                        if (reason) foundWarning.reason = reason;
+
+                        await repository.save(foundWarning);
+
+                        const response = this.client.util.getContainerBuilder(true, 'Update warning')
+                            .addTextDisplayComponents(builder => builder.setContent(`Successfully updated warning with ID \`${id}\` from User <@${foundWarning.user}>\n**Reason:** \`${foundWarning.reason}\`${reportRef ? `\n**Report reference:** <#${reportRef.id}>` : ''}`));
+                        return await interaction.editReply({ components: [response], flags: MessageFlags.IsComponentsV2, allowedMentions: { "parse": [] } });
+                    } else {
+                        const response = this.client.util.getContainerBuilder(false, 'Update warning')
+                            .addTextDisplayComponents(builder => builder.setContent(`Could not find a warning with ID \`${id}\``));
+                        return await interaction.editReply({ components: [response], flags: MessageFlags.IsComponentsV2 });
+                    }
+                } else {
+                    const response = this.client.util.getContainerBuilder(false, 'Update warning')
+                        .addTextDisplayComponents(builder => builder.setContent('You have to provide an ID to update a warning!'));
+                    return await interaction.editReply({ components: [response], flags: MessageFlags.IsComponentsV2 });
+                }
             default:
                 break;
         }


### PR DESCRIPTION
- update warnings option
- reportReference can only be threads
- only show reference when existing
- typo fix in /download
- download-log will properly be sent in log-channel
- changed internal filenames for archived-files
- distinguished download vs archive