### PR TITLE
Bot Update

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "dependencies": {
         "@types/node-cron": "^3.0.11",
         "axios": "^1.10.0",
-        "discord-api-types": "^0.38.1",
-        "discord.js": "^14.22.1",
+        "discord-api-types": "^0.38.33",
+        "discord.js": "^14.24.2",
         "dotenv": "^16.6.1",
         "googleapis": "^155.0.1",
         "jsonc-parser": "^3.3.1",

--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -15,6 +15,7 @@ import { Warning } from "./entity/Warning"
 import { Timeout } from "./entity/Timeout"
 import { LearnerHour } from "./entity/LearnerHour"
 import { LearnerHourParticipation } from "./entity/LearnerHourParticipation"
+import { HostParticipation } from "./entity/HostParticipation"
 
 export const AppDataSource = new DataSource({
     type: "sqlite",
@@ -36,7 +37,8 @@ export const AppDataSource = new DataSource({
         Warning,
         Timeout,
         LearnerHour,
-        LearnerHourParticipation
+        LearnerHourParticipation,
+        HostParticipation
     ],
     migrations: [],
     subscribers: [],

--- a/src/GuildSpecifics.ts
+++ b/src/GuildSpecifics.ts
@@ -70,7 +70,7 @@ export function getChannels(guildId: string | undefined) : Channels {
             learnerHosts: '1411662134756118569',
             staffTicketsCategory: '1415817949868068976',
             teachersChat: '1405664850469847122',
-            librarianTicketsCategory: '1412871767932010547'
+            lorebookTicketsCategory: '1412871767932010547'
         }
     }
 
@@ -106,7 +106,7 @@ export function getChannels(guildId: string | undefined) : Channels {
             wipTicketCategory: '1404834663339528362',
             staffTicketsCategory: '1416098705127375068',
             // Learner Section Channels
-            librarianTicketsCategory: '1439305836873777333',
+            lorebookTicketsCategory: '1439305836873777333',
             learnerTicketsCategory: '1412878315395481782',
             learnerCategory: '1404510300715356232',
             learnerTempVCCreate: '1405678891565187112',
@@ -193,7 +193,7 @@ export function getRoles(guildId: string | undefined, stripRole: boolean = false
             reaper: '1391860635347849374',
             teacher: '1412871872374116463',
             helperLearner: '1412871872374116463',
-            librarian: '1412871872374116463',
+            lorebook: '1441892735144558776',
 
             CONTENT_CREATOR_ROLE: '1391860635456901393',
             LIVE_ROLE: '1391860635456901398',
@@ -260,7 +260,7 @@ export function getRoles(guildId: string | undefined, stripRole: boolean = false
             reaper: '1390444833537130568',
             teacher: '1412881470673916077',
             helperLearner: '1404509333185892422',
-            librarian: '1405001670101827617',
+            lorebook: '1405001670101827617',
             editor: '1389397640533250058',
 
             nitroBooster: '000000000000000000',

--- a/src/GuildSpecifics.ts
+++ b/src/GuildSpecifics.ts
@@ -70,7 +70,9 @@ export function getChannels(guildId: string | undefined) : Channels {
             learnerHosts: '1411662134756118569',
             staffTicketsCategory: '1415817949868068976',
             teachersChat: '1405664850469847122',
-            lorebookTicketsCategory: '1412871767932010547'
+            lorebookTicketsCategory: '1412871767932010547',
+            trialHosts: '1411662134756118569',
+            trialLounge: '1405664850469847122',
         }
     }
 
@@ -116,6 +118,7 @@ export function getChannels(guildId: string | undefined) : Channels {
             teachersChat: '1404510586536202453',
             // Trial Team Channels
             trialCategory: '1416026683659780148',
+            trialHosts: '1441933810873667734',
             trialApplications: '1389392070820630611',
             trialLounge: '1416026842753798276',
             vodReview: '1416027312369172481',

--- a/src/entity/HostParticipation.ts
+++ b/src/entity/HostParticipation.ts
@@ -1,0 +1,31 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn } from "typeorm"
+
+@Entity()
+export class HostParticipation {
+
+    @PrimaryGeneratedColumn()
+    id: number
+
+    // 0 = learner-hour, 1 = lorebook-kill, 2 = trial-hour
+    @Column()
+    type: number
+
+    // user who participated
+    @Column()
+    user: string
+
+    // did they host? 0 = no, 1 = yes
+    @Column()
+    host: number
+
+    // did they participate? 0 = no, 1 = yes
+    @Column({ default: 1})
+    participate: number
+
+    // link to host message, if host came through a card
+    @Column({ nullable: true })
+    link: string
+
+    @CreateDateColumn({ name: 'created_at'})
+    createdAt: Date;
+}

--- a/src/events/MessageCreate.ts
+++ b/src/events/MessageCreate.ts
@@ -91,7 +91,7 @@ export default class MessageCreate extends BotEvent {
         }
 
         // Report-Message-Sync
-        if (message.channel.name.toLowerCase().startsWith('report')) {
+        if (message.channel.name.toLowerCase().startsWith('report') || message.channel.name.toLowerCase().startsWith('clearance')) {
             await TicketHandler.SyncMessage(this.client, message);
         }
     }

--- a/src/events/MessageCreate.ts
+++ b/src/events/MessageCreate.ts
@@ -1,5 +1,6 @@
 import { Message, MessageType } from 'discord.js';
 import BotEvent from '../types/BotEvent';
+import TicketHandler from '../modules/TicketHandler';
 
 export default class MessageCreate extends BotEvent {
     get name() {
@@ -87,6 +88,11 @@ export default class MessageCreate extends BotEvent {
                 });
                 return message.reply('Sorry, I couldn\'t create an invite to your voice channel. Make sure I have the "Create Instant Invite" permission!');
             }
+        }
+
+        // Report-Message-Sync
+        if (message.channel.name.toLowerCase().startsWith('report')) {
+            await TicketHandler.SyncMessage(this.client, message);
         }
     }
 }

--- a/src/interactions/admin/GivePoints.ts
+++ b/src/interactions/admin/GivePoints.ts
@@ -1,11 +1,6 @@
 import BotInteraction from '../../types/BotInteraction';
-import { ChatInputCommandInteraction, SlashCommandBuilder, EmbedBuilder, User } from 'discord.js';
-import { TrialParticipation } from '../../entity/TrialParticipation';
-import { Trial } from '../../entity/Trial';
-import { Reaper } from '../../entity/Reaper';
-import { ReaperParticipation } from '../../entity/ReaperParticipation';
-import { LearnerHour } from '../../entity/LearnerHour';
-import { LearnerHourParticipation } from '../../entity/LearnerHourParticipation';
+import { ChatInputCommandInteraction, SlashCommandBuilder, EmbedBuilder, User, MessageFlags } from 'discord.js';
+import { HostParticipation } from '../../entity/HostParticipation';
 
 export default class GivePoints extends BotInteraction {
     get name() {
@@ -23,8 +18,21 @@ export default class GivePoints extends BotInteraction {
     get featureOptions() {
         const assignOptions: any = {
             'Trial Team': 'trial',
-            'Reaper': 'reaper',
+            'Lore Book Crew': 'lorebook',
             'Teacher': 'teacher',
+        }
+        const options: any = [];
+        Object.keys(assignOptions).forEach((key: string) => {
+            options.push({ name: key, value: assignOptions[key] })
+        })
+        return options;
+    }
+
+    get typeOptions() {
+        const assignOptions: any = {
+            'Host': 'host',
+            'Participation': 'participation',
+            'Both': 'both',
         }
         const options: any = [];
         Object.keys(assignOptions).forEach((key: string) => {
@@ -40,82 +48,40 @@ export default class GivePoints extends BotInteraction {
             .addStringOption((option) => option.setName('team').setDescription('Team').addChoices(
                 ...this.featureOptions
             ).setRequired(true))
+            .addStringOption((option) => option.setName('type').setDescription('Type').addChoices(
+                ...this.typeOptions
+            ).setRequired(true))
             .addUserOption((option) => option.setName('user').setDescription('User').setRequired(true))
-            .addIntegerOption((option) => option.setName('quantity').setDescription('Quantity of points').setRequired(true))
+            .addIntegerOption((option) => option.setName('quantity').setDescription('Quantity of points').setRequired(true));
     }
 
     async run(interaction: ChatInputCommandInteraction) {
-        await interaction.deferReply({ ephemeral: true });
+        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
         const team: string = interaction.options.getString('team', true);
+        const type: string = interaction.options.getString('type', true);
         const user: User = interaction.options.getUser('user', true);
         const quantity: number = interaction.options.getInteger('quantity', true);
 
         const { dataSource } = this.client;
         const { colours } = this.client.util;
 
-        if (team === 'trial') {
-            const repository = dataSource.getRepository(Trial);
-            const placeholder = new Trial();
-            placeholder.host = 'Placeholder';
-            placeholder.link = 'Placeholder';
-            placeholder.trialee = 'Placeholder';
-            placeholder.role = 'Placeholder';
-            const newPlaceholder = await repository.save(placeholder);
+        const template = new HostParticipation();
+        template.user = user.id;
+        template.host = type === 'host' || type === 'both' ? 1 : 0;
+        template.participate = type === 'participation' || type === 'both' ? 1 : 0;
+        template.type = team === 'teacher' ? 0 : team === 'lorebook' ? 1 : team === 'trial' ? 2 : -1;
 
-            const newData: any = [...Array(quantity)].map(() => ({
-                participant: user.id,
-                role: 'Placeholder',
-                trial: newPlaceholder
-            }));
-
-            await dataSource
-                .createQueryBuilder()
-                .insert()
-                .into(TrialParticipation)
-                .values(newData)
-                .execute();
+        const newData: HostParticipation[] = [];
+        for (let index = 0; index < quantity; index++) {
+            newData.push(template);
         }
 
-        if (team === 'reaper') {
-            const reaperRepo = dataSource.getRepository(Reaper);
-            const placeholder = new Reaper();
-            placeholder.host = 'Placeholder';
-            placeholder.link = 'Placeholder';
-            placeholder.recipient = 'Placeholder';
-            const newPlaceholder = await reaperRepo.save(placeholder);
-
-            const newData: any = [...Array(quantity)].map(() => ({
-                participant: user.id,
-                reaper: newPlaceholder
-            }));
-
-            await dataSource
-                .createQueryBuilder()
-                .insert()
-                .into(ReaperParticipation)
-                .values(newData)
-                .execute();
-        }
-
-        if (team === 'teacher') {
-            const teacherRepo = dataSource.getRepository(LearnerHour);
-            const placeholder = new LearnerHour();
-            placeholder.host = 'Placeholder';
-            placeholder.link = 'Placeholder';
-            const newPlaceholder = await teacherRepo.save(placeholder);
-
-            const newData: any = [...Array(quantity)].map(() => ({
-                participant: user.id,
-                learnerHour: newPlaceholder
-            }));
-
-            await dataSource
-                .createQueryBuilder()
-                .insert()
-                .into(LearnerHourParticipation)
-                .values(newData)
-                .execute();
-        }
+        await dataSource
+            .createQueryBuilder()
+            .insert()
+            .into(HostParticipation)
+            .values(newData)
+            .execute();
 
         const replyEmbed = new EmbedBuilder()
             .setTitle('Points successfully granted!')

--- a/src/interactions/admin/RemovePoints.ts
+++ b/src/interactions/admin/RemovePoints.ts
@@ -1,11 +1,6 @@
 import BotInteraction from '../../types/BotInteraction';
-import { ChatInputCommandInteraction, SlashCommandBuilder, EmbedBuilder, User } from 'discord.js';
-import { TrialParticipation } from '../../entity/TrialParticipation';
-import { Trial } from '../../entity/Trial';
-import { Reaper } from '../../entity/Reaper';
-import { ReaperParticipation } from '../../entity/ReaperParticipation';
-import { LearnerHour } from '../../entity/LearnerHour';
-import { LearnerHourParticipation } from '../../entity/LearnerHourParticipation';
+import { ChatInputCommandInteraction, SlashCommandBuilder, EmbedBuilder, User, MessageFlags } from 'discord.js';
+import { HostParticipation } from '../../entity/HostParticipation';
 
 export default class RemovePoints extends BotInteraction {
     get name() {
@@ -23,8 +18,21 @@ export default class RemovePoints extends BotInteraction {
     get featureOptions() {
         const assignOptions: any = {
             'Trial Team': 'trial',
-            'Reaper': 'reaper',
+            'Lore Book Crew': 'lorebook',
             'Teacher': 'teacher',
+        }
+        const options: any = [];
+        Object.keys(assignOptions).forEach((key: string) => {
+            options.push({ name: key, value: assignOptions[key] })
+        })
+        return options;
+    }
+
+    get typeOptions() {
+        const assignOptions: any = {
+            'Host': 'host',
+            'Participation': 'participation',
+            'Both': 'both',
         }
         const options: any = [];
         Object.keys(assignOptions).forEach((key: string) => {
@@ -40,103 +48,49 @@ export default class RemovePoints extends BotInteraction {
             .addStringOption((option) => option.setName('team').setDescription('Team').addChoices(
                 ...this.featureOptions
             ).setRequired(true))
+            .addStringOption((option) => option.setName('type').setDescription('Type').addChoices(
+                ...this.typeOptions
+            ).setRequired(true))
             .addUserOption((option) => option.setName('user').setDescription('User').setRequired(true))
             .addIntegerOption((option) => option.setName('quantity').setDescription('Quantity of points').setRequired(true))
     }
 
     async run(interaction: ChatInputCommandInteraction) {
-        await interaction.deferReply({ ephemeral: true });
+        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
         const team: string = interaction.options.getString('team', true);
+        const type: string = interaction.options.getString('type', true);
         const user: User = interaction.options.getUser('user', true);
         const quantity: number = interaction.options.getInteger('quantity', true);
 
         const { dataSource } = this.client;
         const { colours } = this.client.util;
 
-        if (team === 'trial') {
-            const repository = dataSource.getRepository(Trial);
-            let existingPlaceholder = await repository.findOne({
-                where: {
-                    host: 'Placeholder'
-                }
-            })
-            if (!existingPlaceholder) {
-                const placeholder = new Trial();
-                placeholder.host = 'Placeholder';
-                placeholder.link = 'Placeholder';
-                placeholder.trialee = 'Placeholder';
-                placeholder.role = 'Placeholder';
-                existingPlaceholder = await repository.save(placeholder);
-            }
-            const participationRepo = dataSource.getRepository(TrialParticipation);
-            let participationToDelete = await participationRepo.find({
-                where: {
-                    participant: user.id,
-                },
-                take: quantity,
-            });
-            if (participationToDelete) {
-                await participationRepo.remove(participationToDelete);
-            }
+        // find hosts to remove points from
+        const repository = dataSource.getRepository(HostParticipation);
+
+        const hosts = await repository.find({
+            where: {
+                type: team === 'teacher' ? 0 : team === 'lorebook' ? 1 : team === 'trial' ? 2 : -1,
+                host: type === 'host' || type === 'both' ? 1 : 0,
+                participate: type === 'participation' || type === 'both' ? 1: 0
+            },
+            take: quantity
+        });
+
+        if (hosts.length >= quantity) {
+            await repository.remove(hosts);
+
+            const replyEmbed = new EmbedBuilder()
+                .setTitle('Points successfully removed!')
+                .setColor(colours.discord.green)
+                .setDescription(`<@${user.id}> was successfully removed **${quantity}** points.`);
+            await interaction.editReply({ embeds: [replyEmbed] });
+        } else {
+            const replyEmbed = new EmbedBuilder()
+                .setTitle('Points can\'t be removed!')
+                .setColor(colours.discord.red)
+                .setDescription(`<@${user.id}> has not enough points to be removed.`);
+            await interaction.editReply({ embeds: [replyEmbed] });
         }
-
-        if (team === 'reaper') {
-            const reaperRepo = dataSource.getRepository(Reaper);
-            let existingPlaceholder = await reaperRepo.findOne({
-                where: {
-                    host: 'Placeholder'
-                }
-            })
-            if (!existingPlaceholder) {
-                const placeholder = new Reaper();
-                placeholder.host = 'Placeholder';
-                placeholder.link = 'Placeholder';
-                placeholder.recipient = 'Placeholder';
-                existingPlaceholder = await reaperRepo.save(placeholder);
-            }
-            const participationRepo = dataSource.getRepository(ReaperParticipation);
-            let participationToDelete = await participationRepo.find({
-                where: {
-                    participant: user.id,
-                },
-                take: quantity,
-            });
-            if (participationToDelete) {
-                await participationRepo.remove(participationToDelete);
-
-            }
-        }
-
-        if (team === 'teacher') {
-            const learnerHourRepo = dataSource.getRepository(LearnerHour);
-            let existingPlaceholder = await learnerHourRepo.findOne({
-                where: {
-                    host: 'Placeholder'
-                }
-            })
-            if (!existingPlaceholder) {
-                const placeholder = new LearnerHour();
-                placeholder.host = 'Placeholder';
-                placeholder.link = 'Placeholder';
-                existingPlaceholder = await learnerHourRepo.save(placeholder);
-            }
-            const participationRepo = dataSource.getRepository(LearnerHourParticipation);
-            let participationToDelete = await participationRepo.find({
-                where: {
-                    participant: user.id,
-                },
-                take: quantity,
-            });
-            if (participationToDelete) {
-                await participationRepo.remove(participationToDelete);
-
-            }
-        }
-
-        const replyEmbed = new EmbedBuilder()
-            .setTitle('Points successfully removed!')
-            .setColor(colours.discord.green)
-            .setDescription(`<@${user.id}> was successfully removed **${quantity}** points.`);
-        await interaction.editReply({ embeds: [replyEmbed] });
     }
 }

--- a/src/interactions/admin/Say.ts
+++ b/src/interactions/admin/Say.ts
@@ -1,5 +1,5 @@
 import BotInteraction from '../../types/BotInteraction';
-import { Attachment, ChatInputCommandInteraction, SlashCommandBuilder, TextChannel, ModalBuilder, TextInputBuilder, TextInputStyle, ActionRowBuilder, ModalSubmitInteraction, Channel } from 'discord.js';
+import { Attachment, ChatInputCommandInteraction, SlashCommandBuilder, TextChannel, ModalBuilder, TextInputBuilder, TextInputStyle, ActionRowBuilder, ModalSubmitInteraction, Channel, MessageFlags } from 'discord.js';
 
 export default class Say extends BotInteraction {
     get name() {
@@ -55,7 +55,7 @@ export default class Say extends BotInteraction {
                 await channel.send(attachment ? { content: parsedMessage, files: [attachment] } : { content: parsedMessage });
             }
 
-            await modalInteraction.reply({ content: `Message sent!`, ephemeral: true });
+            await modalInteraction.reply({ content: `Message sent!`, flags: MessageFlags.Ephemeral });
         } catch (err) {
             console.error('Say command error:', err);
         }

--- a/src/interactions/admin/UpdateBossKph.ts
+++ b/src/interactions/admin/UpdateBossKph.ts
@@ -1,5 +1,5 @@
 import BotInteraction from '../../types/BotInteraction';
-import { ChatInputCommandInteraction, SlashCommandBuilder, EmbedBuilder } from 'discord.js';
+import { ChatInputCommandInteraction, SlashCommandBuilder, EmbedBuilder, MessageFlags } from 'discord.js';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -38,7 +38,7 @@ export default class UpdateBossKph extends BotInteraction {
     async run(interaction: ChatInputCommandInteraction) {
         if (!interaction.inCachedGuild()) return;
 
-        await interaction.deferReply({ ephemeral: true });
+        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
         const boss = interaction.options.getString('boss', true);
         const newKph = interaction.options.getNumber('kph', true);

--- a/src/interactions/bot_owner/Eval.ts
+++ b/src/interactions/bot_owner/Eval.ts
@@ -28,7 +28,7 @@ export default class Eval extends BotInteraction {
     }
 
     async run(interaction: ChatInputCommandInteraction<any>) {
-        await interaction.deferReply({ ephemeral: false });
+        await interaction.deferReply();
         const code = interaction.options.getString('code', true);
         let res;
         try {

--- a/src/interactions/bot_owner/Query.ts
+++ b/src/interactions/bot_owner/Query.ts
@@ -1,0 +1,51 @@
+import { ChatInputCommandInteraction, SlashCommandBuilder, SlashCommandStringOption, MessageFlags } from 'discord.js';
+import BotInteraction from '../../types/BotInteraction';
+
+export default class Query extends BotInteraction {
+    get name() {
+        return 'query';
+    }
+
+    get description() {
+        return 'Send a database query to the db';
+    }
+
+    get permissions() {
+        return 'BOT_OWNER';
+    }
+
+    get slashData() {
+        return new SlashCommandBuilder()
+            .setName(this.name)
+            .setDescription(this.description)
+            .addStringOption((option: SlashCommandStringOption) => option.setName('query').setDescription('Query to execute.').setRequired(true));
+    }
+
+    static trim(string: string, max: number): string {
+        return string.length > max ? string.slice(0, max) : string;
+    }
+
+    async run(interaction: ChatInputCommandInteraction<any>) {
+        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+        const query = interaction.options.getString('query', true);
+
+        if (interaction.channel && 'send' in interaction.channel) {
+            let result = await this.client.dataSource.query(query);
+            result = JSON.stringify(result, null, 2);
+
+            this.client.logger.log({
+                message: `${interaction.user.id} (${interaction.user.displayName}) executed the following query: '${query}'`
+            }, true);
+
+            for (let i = 0; i < result.length; i += 1950) {
+                await interaction.followUp({
+                    content: `\`\`\`json\n${result.slice(i, i + 1950)}\n\`\`\``,
+                    flags: MessageFlags.Ephemeral
+                });
+            }
+            return;
+        }
+
+        return await interaction.editReply('Command needs to be executed in a textbased channel');
+    }
+}

--- a/src/interactions/editor/Download.ts
+++ b/src/interactions/editor/Download.ts
@@ -1,5 +1,5 @@
 import BotInteraction from '../../types/BotInteraction';
-import { SlashCommandBuilder, ChatInputCommandInteraction, TextChannel, AttachmentBuilder, ChannelType, APIEmbed } from 'discord.js';
+import { SlashCommandBuilder, ChatInputCommandInteraction, TextChannel, AttachmentBuilder, ChannelType, APIEmbed, MessageFlags } from 'discord.js';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import ComponentsV2Utils from '../../modules/ComponentsV2Utils';
@@ -45,7 +45,7 @@ export default class Download extends BotInteraction {
     }
 
     async run(interaction: ChatInputCommandInteraction) {
-        await interaction.deferReply({ ephemeral: true });
+        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
         const channel = interaction.options.getChannel('channel', true) as TextChannel;
         const archived = (interaction.options.getString('archived', false) ?? 'yes') === 'yes';

--- a/src/interactions/editor/Upload.ts
+++ b/src/interactions/editor/Upload.ts
@@ -312,7 +312,7 @@ export default class Upload extends BotInteraction {
 
                 await interaction.followUp({
                     content: errorDetails,
-                    ephemeral: true,
+                    flags: MessageFlags.Ephemeral,
                 });
                 return;
             }
@@ -380,14 +380,14 @@ export default class Upload extends BotInteraction {
                     if (chunks.length > 0) {
                         await interaction.followUp({
                             content: `**${summary}**\n\n**Corrected file:**\n\`\`\`json\n${chunks[0]}\n\`\`\``,
-                            ephemeral: true,
+                            flags: MessageFlags.Ephemeral,
                         });
                     }
 
                     for (let i = 1; i < chunks.length; i++) {
                         await interaction.followUp({
                             content: `\`\`\`json\n${chunks[i]}\n\`\`\``,
-                            ephemeral: true,
+                            flags: MessageFlags.Ephemeral,
                         });
                     }
                 }
@@ -524,7 +524,7 @@ export default class Upload extends BotInteraction {
                 const chunk = textChunks.slice(i, i + 2);
                 await interaction.followUp({
                     content: `**Link Errors Found**\nI've provided suggestions for the segments below. You can copy the corrected versions.\n\n${chunk.join('\n\n')}`,
-                    ephemeral: true,
+                    flags: MessageFlags.Ephemeral,
                 });
             }
 

--- a/src/interactions/lorebook/FinishLoreBook.ts
+++ b/src/interactions/lorebook/FinishLoreBook.ts
@@ -1,0 +1,27 @@
+import HostHandler from '../../modules/HostHandler';
+import BotInteraction from '../../types/BotInteraction';
+import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
+
+export default class FinishLoreBook extends BotInteraction {
+    get name() {
+        return 'finish-lorebook';
+    }
+
+    get description() {
+        return 'Finish a Lore Book kill';
+    }
+
+    get permissions() {
+        return 'LOREBOOK';
+    }
+
+    get slashData() {
+        return new SlashCommandBuilder()
+            .setName(this.name)
+            .setDescription(this.description);
+    }
+
+    async run(interaction: ChatInputCommandInteraction) {
+        return new HostHandler(this.client, 'host_lorebook_quickfinish', interaction);
+    }
+}

--- a/src/interactions/lorebook/HostLoreBook.ts
+++ b/src/interactions/lorebook/HostLoreBook.ts
@@ -31,7 +31,7 @@ export default class HostLoreBook extends BotInteraction {
 
         const learnerHostChannel = await interaction.guild?.channels.fetch(this.client.channelIds.learnerHosts) as TextChannel;
 
-        const success = await HostHandler.postHost(learnerHostChannel, 'nm', message, [learner.id], [interaction.user.id]);
+        const success = await HostHandler.postHost(learnerHostChannel, 'nm', message, [learner.id], [interaction.user.id], null, 1);
 
         const container = this.client.cv2.getContainerBuilder(success, "Host card creation");
         container.addTextDisplayComponents(builder => builder.setContent(success ? "Your host has been successfully created!" : "Your host could not be created!"));

--- a/src/interactions/lorebook/HostLoreBook.ts
+++ b/src/interactions/lorebook/HostLoreBook.ts
@@ -2,54 +2,36 @@ import BotInteraction from '../../types/BotInteraction';
 import { ChatInputCommandInteraction, SlashCommandBuilder, TextChannel, MessageFlags, User } from 'discord.js';
 import HostHandler from '../../modules/HostHandler';
 
-export default class HostLearner extends BotInteraction {
+export default class HostLoreBook extends BotInteraction {
     get name() {
-        return 'host-learner';
+        return 'host-lorebook';
     }
 
     get description() {
-        return 'Set up a learner Host Card';
+        return 'Set up a Lore Book Host Card';
     }
 
     get permissions() {
-        return 'TEACHER';
-    }
-
-    get enrageOptions() {
-        const enrage: any = {
-            'Normal Mode': 'nm',
-            'Enrage Mode - 100%': '100',
-            'Enrage Mode - 500%': '500',
-            'Enrage Mode - 750%': '750',
-            'Enrage Mode - 1000%': '1000',
-            'Enrage Mode - 2000%': '2000',
-        }
-        const options: any = [];
-        Object.keys(enrage).forEach((key: string) => {
-            options.push({ name: key, value: enrage[key] })
-        })
-        return options;
+        return 'LOREBOOK';
     }
 
     get slashData() {
         return new SlashCommandBuilder()
             .setName(this.name)
             .setDescription(this.description)
-            .addStringOption((option) => option.setName('mode').setDescription('Mode and Enrage').setChoices(...this.enrageOptions).setRequired(true))
-            .addUserOption((option) => option.setName('learner').setDescription('Learner to host for').setRequired(true))
+            .addUserOption((option) => option.setName('lorebook').setDescription('Person to host for').setRequired(true))
             .addStringOption((option) => option.setName('message').setDescription('Add a Message').setRequired(false));
     }
 
     async run(interaction: ChatInputCommandInteraction) {
         await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
-        const mode: string = interaction.options.getString('mode', true);
         const message: string | null = interaction.options.getString('message', false);
-        const learner: User = interaction.options.getUser('learner', true);
+        const learner: User = interaction.options.getUser('lorebook', true);
 
         const learnerHostChannel = await interaction.guild?.channels.fetch(this.client.channelIds.learnerHosts) as TextChannel;
 
-        const success = await HostHandler.postHost(learnerHostChannel, mode, message, [learner.id], [interaction.user.id]);
+        const success = await HostHandler.postHost(learnerHostChannel, 'nm', message, [learner.id], [interaction.user.id]);
 
         const container = this.client.cv2.getContainerBuilder(success, "Host card creation");
         container.addTextDisplayComponents(builder => builder.setContent(success ? "Your host has been successfully created!" : "Your host could not be created!"));

--- a/src/interactions/lorebook/LoreBookLeaderboard.ts
+++ b/src/interactions/lorebook/LoreBookLeaderboard.ts
@@ -2,17 +2,17 @@ import LeaderboardHandler from '../../modules/LeaderboardHandler';
 import BotInteraction from '../../types/BotInteraction';
 import { ChatInputCommandInteraction, MessageFlags, SlashCommandBuilder, TextChannel } from 'discord.js';
 
-export default class TeacherLeaderboard extends BotInteraction {
+export default class LoreBookLeaderboard extends BotInteraction {
     get name() {
-        return 'teacher-leaderboard';
+        return 'lorebook-leaderboard';
     }
 
     get description() {
-        return 'Teacher Leaderboards';
+        return 'Lore Book Leaderboards';
     }
 
     get permissions() {
-        return 'TEACHER';
+        return 'LOREBOOK';
     }
 
     get timespanOptions() {
@@ -44,7 +44,7 @@ export default class TeacherLeaderboard extends BotInteraction {
         await interaction.deferReply({ flags: MessageFlags.Ephemeral });
         const timespan: string | null = interaction.options.getString('timespan', false);
 
-        await LeaderboardHandler.postLeaderBoard(this.client, 0, interaction.channel as TextChannel, timespan ?? null)
+        await LeaderboardHandler.postLeaderBoard(this.client, 1, interaction.channel as TextChannel, timespan ?? null)
 
         await interaction.editReply('Leaderboard sent!');
     }

--- a/src/interactions/moderation/TicketStatistics.ts
+++ b/src/interactions/moderation/TicketStatistics.ts
@@ -25,7 +25,7 @@ export default class TicketStatistics extends BotInteraction {
             'Other': 3,
             'Clearance': 4,
             'Learner': 5,
-            'Librarian' : 6,
+            'Lore Book' : 6,
             'Support': 7,
             'Teacher': 8,
             'Trial Team': 9
@@ -120,10 +120,10 @@ export default class TicketStatistics extends BotInteraction {
             const ticketType = ticket.type;
 
             if (detailed) {
-                message += `Ticket Type: ${(ticketType === 0 ? 'Suggestion' : ticketType === 1 ? 'Report' : ticketType === 2 ? 'Content Creator' : ticketType === 4 ? 'Clearance' : ticketType === 5 ? 'Learner' : ticketType === 6 ? 'Librarian' :
+                message += `Ticket Type: ${(ticketType === 0 ? 'Suggestion' : ticketType === 1 ? 'Report' : ticketType === 2 ? 'Content Creator' : ticketType === 4 ? 'Clearance' : ticketType === 5 ? 'Learner' : ticketType === 6 ? 'Lore Book' :
                     ticketType === 7 ? 'Support' : ticketType === 8 ? 'Teacher' : ticketType === 9 ? 'Trial Team' : 'Other' )} | Opened by: <@${ticket.userOpen}> | Closed by: <@${ticket.userClose}> | Archive: <#${ticket.forumPostId}>\n`;
             } else {
-                message += `Ticket Type: ${(ticketType === 0 ? 'Suggestion' : ticketType === 1 ? 'Report' : ticketType === 2 ? 'Content Creator' : ticketType === 4 ? 'Clearance' : ticketType === 5 ? 'Learner' : ticketType === 6 ? 'Librarian' :
+                message += `Ticket Type: ${(ticketType === 0 ? 'Suggestion' : ticketType === 1 ? 'Report' : ticketType === 2 ? 'Content Creator' : ticketType === 4 ? 'Clearance' : ticketType === 5 ? 'Learner' : ticketType === 6 ? 'Lore Book' :
                     ticketType === 7 ? 'Support' : ticketType === 8 ? 'Teacher' : ticketType === 9 ? 'Trial Team' : 'Other' )} | Ticket Count: ${ticket.count}\n`;
             }
         });
@@ -142,7 +142,7 @@ export default class TicketStatistics extends BotInteraction {
                 `> Ticket Stats from <t:${Math.round(dateFrom.getTime() / 1000)}:f> to <t:${Math.round(dateTo.getTime() / 1000)}:f>.`,
                 userOpen ? `> Opening User: <@${userOpen.id}>` : '',
                 userClose ? `> Closing User: <@${userClose.id}>` : '',
-                type != null ? '> Ticket-Type: ' + (type === 0 ? 'Suggestion' : type === 1 ? 'Report' : type === 2 ? 'Content Creator' : type === 4 ? 'Clearance' : type === 5 ? 'Learner' : type === 6 ? 'Librarian' :
+                type != null ? '> Ticket-Type: ' + (type === 0 ? 'Suggestion' : type === 1 ? 'Report' : type === 2 ? 'Content Creator' : type === 4 ? 'Clearance' : type === 5 ? 'Learner' : type === 6 ? 'Lore Book' :
                     type === 7 ? 'Support' : type === 8 ? 'Teacher' : type === 9 ? 'Trial Team' : 'Other') : '',
                 !userOpen && !userClose && type == null ? '> No additional Filter specified' : '',
             ].filter(str => str.trim() !== '').join('\n').trim()));

--- a/src/interactions/moderation/Warn.ts
+++ b/src/interactions/moderation/Warn.ts
@@ -114,77 +114,9 @@ export default class Warn extends BotInteraction {
                 }
 
             case 2:
-                // List warnings
-                let foundWarnings: Warning[] | null = await repository.find({
-                    order: {
-                        createdAt: 'ASC'
-                    }
-                });
-                let filters: string = '';
-
-                if (id) {
-                    foundWarnings = foundWarnings.filter(x => x.id === id);
-                    filters += `\n- **ID:** \`${id}\``;
-                }
-
-                if (user) {
-                    foundWarnings = foundWarnings.filter(x => x.user === user.id);
-                    filters += `\n- **User:** <@${user.id}>`;
-                }
-
-                if (reportRef) {
-                    foundWarnings = foundWarnings.filter(x => x.reportRef === reportRef.id);
-                    filters += `\n- **Report reference:** \`${reportRef}\``;
-                }
-
-                if (foundWarnings.length > 0 && foundWarnings.length < 25) {
-                    const response = this.client.cv2.getContainerBuilder(null, `List warnings - \`${foundWarnings.length}\` found`);
-
-                    let content: string = '';
-
-                    if (id) {
-                        content = `Found warning for ID \`${id}\`:\n\n`
-                    } else if (user) {
-                        content = `Found warnings for User <@${user.id}>:\n\n`
-                    } else if (reportRef) {
-                        content = `Found warnings for report reference \`${reportRef}\`:\n\n`
-                    } else {
-                        content = `Found warnings:\n\n`
-                    }
-
-                    for (const warning of foundWarnings) {
-                        if (id) {
-                            content += `**User:** <@${warning.user}>\n`
-                            content += `**Reason:** \`${warning.reason}\`\n`;
-                            if (warning.reportRef) content += `**Report reference:** <#${warning.reportRef}>\n`;
-                        } else if (user) {
-                            content += `**ID:** \`${warning.id}\`\n`;
-                            content += `**Reason:** \`${warning.reason}\`\n`;
-                            if (warning.reportRef) content += `**Report reference:** <#${warning.reportRef}>\n`;
-                        } else {
-                            content += `**ID:** \`${warning.id}\`\n`;
-                            content += `**User:** <@${warning.user}>\n`;
-                            content += `**Reason:** \`${warning.reason}\`\n`;
-                            if (warning.reportRef) content += `**Report reference:** <#${warning.reportRef}>\n`;
-                        }
-                        content += '\n';
-                    }
-
-                    content = content.trim();
-
-                    response.addTextDisplayComponents(builder => builder.setContent(content));
-
-                    return await interaction.editReply({ components: [response], flags: MessageFlags.IsComponentsV2, allowedMentions: { "parse": [] } });
-                } else if (foundWarnings.length >= 25) {
-                    const response = this.client.cv2.getContainerBuilder(false, 'List warnings')
-                        .addTextDisplayComponents(builder => builder.setContent(`Found too many warnings (\`${foundWarnings.length}\`), please specify your search until a proper pagination system is implemented.`));
-                    return await interaction.editReply({ components: [response], flags: MessageFlags.IsComponentsV2 });
-                } else {
-                    const response = this.client.cv2.getContainerBuilder(false, 'List warnings')
-                        .addTextDisplayComponents(builder => builder.setContent(`Could not find any warnings for the specified filters:${filters.length > 0 ? filters : '\n- No filters provided'}`));
-                    return await interaction.editReply({ components: [response], flags: MessageFlags.IsComponentsV2 });
-                }
-
+                // moved to UtilityHandler
+                const response = await this.client.util.GetWarnings(user, id, reportRef);
+                return await interaction.editReply({ components: [response], flags: MessageFlags.IsComponentsV2, allowedMentions: { "parse": [] } });
             case 3:
                 if (id) {
                     const foundWarning: Warning | null = await repository.findOne({

--- a/src/interactions/role-management/AssignCosmetic.ts
+++ b/src/interactions/role-management/AssignCosmetic.ts
@@ -1,5 +1,5 @@
 import BotInteraction from '../../types/BotInteraction';
-import { ChatInputCommandInteraction, SlashCommandBuilder, User, Role, TextChannel, EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle, AutocompleteInteraction } from 'discord.js';
+import { ChatInputCommandInteraction, SlashCommandBuilder, User, Role, TextChannel, EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle, AutocompleteInteraction, MessageFlags } from 'discord.js';
 
 interface Hierarchy {
     [key: string]: string[];
@@ -94,7 +94,7 @@ export default class Pass extends BotInteraction {
     }
 
     async run(interaction: ChatInputCommandInteraction) {
-        await interaction.deferReply({ ephemeral: true });
+        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
         const userResponse: User = interaction.options.getUser('user', true);
         const role: string = interaction.options.getString('role', true);
 

--- a/src/interactions/role-management/AssignMatchmaking.ts
+++ b/src/interactions/role-management/AssignMatchmaking.ts
@@ -121,8 +121,9 @@ export default class Pass extends BotInteraction {
         const member = await interaction.guild.members.fetch(interaction.user.id);
         const hasAdminPermissions = await this.client.util.hasRolePermissions(this.client, ['admin', 'owner'], interaction);
         const hasTrialTeamPermissions = member.roles.cache.has(this.client.roleIds.trialTeam);
+        const hasTeacherPermissions = member.roles.cache.has(this.client.roleIds.teacher);
 
-        if (hasAdminPermissions) {
+        if (hasAdminPermissions || (hasTrialTeamPermissions && hasTeacherPermissions)) {
             choices = allOptions;
         } else if (hasTrialTeamPermissions) {
             choices = trialTeamOptions;

--- a/src/interactions/role-management/AssignMatchmaking.ts
+++ b/src/interactions/role-management/AssignMatchmaking.ts
@@ -1,5 +1,5 @@
 import BotInteraction from '../../types/BotInteraction';
-import { ChatInputCommandInteraction, SlashCommandBuilder, User, Role, TextChannel, EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle } from 'discord.js';
+import { ChatInputCommandInteraction, SlashCommandBuilder, User, Role, TextChannel, EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle, MessageFlags } from 'discord.js';
 
 interface Hierarchy {
     [key: string]: string[];
@@ -139,7 +139,7 @@ export default class Pass extends BotInteraction {
     }
 
     async run(interaction: ChatInputCommandInteraction) {
-        await interaction.deferReply({ ephemeral: true });
+        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
         const userResponse: User = interaction.options.getUser('user', true);
         const role: string = interaction.options.getString('role', true);
 

--- a/src/interactions/role-management/RoleExtend.ts
+++ b/src/interactions/role-management/RoleExtend.ts
@@ -1,4 +1,4 @@
-import { SlashCommandBuilder, ChatInputCommandInteraction, PermissionFlagsBits, Role, GuildMember, AutocompleteInteraction, TextChannel, EmbedBuilder } from "discord.js";
+import { SlashCommandBuilder, ChatInputCommandInteraction, PermissionFlagsBits, Role, GuildMember, AutocompleteInteraction, TextChannel, EmbedBuilder, MessageFlags } from "discord.js";
 import BotInteraction from "../../types/BotInteraction";
 import Bot from "../../Bot";
 
@@ -70,7 +70,7 @@ export default class RoleExtend extends BotInteraction {
             return;
         }
 
-        await interaction.deferReply({ ephemeral: true });
+        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
         const currentRole = interaction.options.getRole('current-role', true) as Role;
         const desiredRole1 = interaction.options.getRole('desired-role-1', true) as Role;
@@ -118,10 +118,10 @@ export default class RoleExtend extends BotInteraction {
                 const membersWithRole = interaction.guild.members.cache.filter(member => member.roles.cache.has(currentRole.id));
 
                 if (membersWithRole.size === 0) {
-                    return interaction.followUp({ content: `${identifier} No one has the ${currentRole.name} role.`, ephemeral: true });
+                    return interaction.followUp({ content: `${identifier} No one has the ${currentRole.name} role.`, flags: MessageFlags.Ephemeral });
                 }
 
-                await interaction.followUp({ content: `${identifier} Found ${membersWithRole.size} members. Starting role extension...`, ephemeral: true });
+                await interaction.followUp({ content: `${identifier} Found ${membersWithRole.size} members. Starting role extension...`, flags: MessageFlags.Ephemeral });
 
                 let successCount = 0;
                 let errorCount = 0;
@@ -139,11 +139,11 @@ export default class RoleExtend extends BotInteraction {
                     }
                 }
 
-                return interaction.followUp({ content: `${identifier} Mass extension complete. Extended the ${currentRole.name} role with ${desiredRole1.name} and ${desiredRole2.name} for ${successCount} members. Failed to extend for ${errorCount} members.`, ephemeral: true });
+                return interaction.followUp({ content: `${identifier} Mass extension complete. Extended the ${currentRole.name} role with ${desiredRole1.name} and ${desiredRole2.name} for ${successCount} members. Failed to extend for ${errorCount} members.`, flags: MessageFlags.Ephemeral });
 
             } catch (error) {
                 this.client.logger.error({ message: `Failed mass role extension for role ${currentRole.name}`, error });
-                return interaction.followUp({ content: `${identifier} An unexpected error occurred during mass extension.`, ephemeral: true });
+                return interaction.followUp({ content: `${identifier} An unexpected error occurred during mass extension.`, flags: MessageFlags.Ephemeral });
             }
         }
     }

--- a/src/interactions/role-management/RoleRemoval.ts
+++ b/src/interactions/role-management/RoleRemoval.ts
@@ -1,4 +1,4 @@
-import { SlashCommandBuilder, ChatInputCommandInteraction, PermissionFlagsBits, Role, GuildMember, AutocompleteInteraction, TextChannel, EmbedBuilder } from "discord.js";
+import { SlashCommandBuilder, ChatInputCommandInteraction, PermissionFlagsBits, Role, GuildMember, AutocompleteInteraction, TextChannel, EmbedBuilder, MessageFlags } from "discord.js";
 import BotInteraction from "../../types/BotInteraction";
 import Bot from "../../Bot";
 
@@ -58,7 +58,7 @@ export default class RoleRemoval extends BotInteraction {
             return;
         }
 
-        await interaction.deferReply({ ephemeral: true });
+        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
         const role = interaction.options.getRole('role', true) as Role;
         const user = interaction.options.getMember('user') as GuildMember | null;
@@ -95,10 +95,10 @@ export default class RoleRemoval extends BotInteraction {
                 const membersWithRole = interaction.guild.members.cache.filter(member => member.roles.cache.has(role.id));
 
                 if (membersWithRole.size === 0) {
-                    return interaction.followUp({ content: `No one has the ${role.name} role.`, ephemeral: true });
+                    return interaction.followUp({ content: `No one has the ${role.name} role.`, flags: MessageFlags.Ephemeral });
                 }
 
-                await interaction.followUp({ content: `Found ${membersWithRole.size} members. Starting role removal...`, ephemeral: true });
+                await interaction.followUp({ content: `Found ${membersWithRole.size} members. Starting role removal...`, flags: MessageFlags.Ephemeral });
 
                 let successCount = 0;
                 let errorCount = 0;
@@ -113,11 +113,11 @@ export default class RoleRemoval extends BotInteraction {
                     }
                 }
 
-                return interaction.followUp({ content: `Mass removal complete. Removed the ${role.name} role from ${successCount} members. Failed to remove from ${errorCount} members.`, ephemeral: true });
+                return interaction.followUp({ content: `Mass removal complete. Removed the ${role.name} role from ${successCount} members. Failed to remove from ${errorCount} members.`, flags: MessageFlags.Ephemeral });
 
             } catch (error) {
                 this.client.logger.error({ message: `Failed mass role removal for role ${role.name}`, error });
-                return interaction.followUp({ content: `An unexpected error occurred during mass removal.`, ephemeral: true });
+                return interaction.followUp({ content: `An unexpected error occurred during mass removal.`, flags: MessageFlags.Ephemeral });
             }
         }
     }

--- a/src/interactions/role-management/RoleReplace.ts
+++ b/src/interactions/role-management/RoleReplace.ts
@@ -1,4 +1,4 @@
-import { SlashCommandBuilder, ChatInputCommandInteraction, PermissionFlagsBits, Role, GuildMember, AutocompleteInteraction, TextChannel, EmbedBuilder } from "discord.js";
+import { SlashCommandBuilder, ChatInputCommandInteraction, PermissionFlagsBits, Role, GuildMember, AutocompleteInteraction, TextChannel, EmbedBuilder, MessageFlags } from "discord.js";
 import BotInteraction from "../../types/BotInteraction";
 import Bot from "../../Bot";
 
@@ -62,7 +62,7 @@ export default class RoleReplace extends BotInteraction {
             return;
         }
 
-        await interaction.deferReply({ ephemeral: true });
+        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
         const currentRole = interaction.options.getRole('current-role', true) as Role;
         const desiredRole = interaction.options.getRole('desired-role', true) as Role;
@@ -100,10 +100,10 @@ export default class RoleReplace extends BotInteraction {
                 const membersWithRole = interaction.guild.members.cache.filter(member => member.roles.cache.has(currentRole.id));
 
                 if (membersWithRole.size === 0) {
-                    return interaction.followUp({ content: `No one has the ${currentRole.name} role.`, ephemeral: true });
+                    return interaction.followUp({ content: `No one has the ${currentRole.name} role.`, flags: MessageFlags.Ephemeral });
                 }
 
-                await interaction.followUp({ content: `Found ${membersWithRole.size} members. Starting role replacement...`, ephemeral: true });
+                await interaction.followUp({ content: `Found ${membersWithRole.size} members. Starting role replacement...`, flags: MessageFlags.Ephemeral });
 
                 let successCount = 0;
                 let errorCount = 0;
@@ -119,11 +119,11 @@ export default class RoleReplace extends BotInteraction {
                     }
                 }
 
-                return interaction.followUp({ content: `Mass replacement complete. Replaced the ${currentRole.name} role with ${desiredRole.name} for ${successCount} members. Failed to replace for ${errorCount} members.`, ephemeral: true });
+                return interaction.followUp({ content: `Mass replacement complete. Replaced the ${currentRole.name} role with ${desiredRole.name} for ${successCount} members. Failed to replace for ${errorCount} members.`, flags: MessageFlags.Ephemeral });
 
             } catch (error) {
                 this.client.logger.error({ message: `Failed mass role replacement for role ${currentRole.name}`, error });
-                return interaction.followUp({ content: `An unexpected error occurred during mass replacement.`, ephemeral: true });
+                return interaction.followUp({ content: `An unexpected error occurred during mass replacement.`, flags: MessageFlags.Ephemeral });
             }
         }
     }

--- a/src/interactions/teacher/FinishLearner.ts
+++ b/src/interactions/teacher/FinishLearner.ts
@@ -1,0 +1,27 @@
+import HostHandler from '../../modules/HostHandler';
+import BotInteraction from '../../types/BotInteraction';
+import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
+
+export default class FinishLearner extends BotInteraction {
+    get name() {
+        return 'finish-learner';
+    }
+
+    get description() {
+        return 'Finish a learner hour';
+    }
+
+    get permissions() {
+        return 'TEACHER';
+    }
+
+    get slashData() {
+        return new SlashCommandBuilder()
+            .setName(this.name)
+            .setDescription(this.description);
+    }
+
+    async run(interaction: ChatInputCommandInteraction) {
+        return new HostHandler(this.client, 'host_learner_quickfinish', interaction);
+    }
+}

--- a/src/interactions/trialteam/FinishTrial.ts
+++ b/src/interactions/trialteam/FinishTrial.ts
@@ -1,0 +1,27 @@
+import HostHandler from '../../modules/HostHandler';
+import BotInteraction from '../../types/BotInteraction';
+import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
+
+export default class FinishTrial extends BotInteraction {
+    get name() {
+        return 'finish-trial';
+    }
+
+    get description() {
+        return 'Finish a Trial';
+    }
+
+    get permissions() {
+        return 'TRIAL_TEAM';
+    }
+
+    get slashData() {
+        return new SlashCommandBuilder()
+            .setName(this.name)
+            .setDescription(this.description);
+    }
+
+    async run(interaction: ChatInputCommandInteraction) {
+        return new HostHandler(this.client, 'host_trial_quickfinish', interaction);
+    }
+}

--- a/src/interactions/trialteam/HostTrial.ts
+++ b/src/interactions/trialteam/HostTrial.ts
@@ -2,23 +2,21 @@ import BotInteraction from '../../types/BotInteraction';
 import { ChatInputCommandInteraction, SlashCommandBuilder, TextChannel, MessageFlags, User } from 'discord.js';
 import HostHandler from '../../modules/HostHandler';
 
-export default class HostLearner extends BotInteraction {
+export default class HostTrial extends BotInteraction {
     get name() {
-        return 'host-learner';
+        return 'host-trial';
     }
 
     get description() {
-        return 'Set up a learner Host Card';
+        return 'Set up a Trial Host Card';
     }
 
     get permissions() {
-        return 'TEACHER';
+        return 'TRIAL_TEAM';
     }
 
     get enrageOptions() {
         const enrage: any = {
-            'Normal Mode': 'nm',
-            'Enrage Mode - 100%': '100',
             'Enrage Mode - 500%': '500',
             'Enrage Mode - 750%': '750',
             'Enrage Mode - 1000%': '1000',
@@ -35,8 +33,8 @@ export default class HostLearner extends BotInteraction {
         return new SlashCommandBuilder()
             .setName(this.name)
             .setDescription(this.description)
-            .addStringOption((option) => option.setName('mode').setDescription('Mode and Enrage').setChoices(...this.enrageOptions).setRequired(true))
-            .addUserOption((option) => option.setName('learner').setDescription('Learner to host for').setRequired(true))
+            .addStringOption((option) => option.setName('mode').setDescription('Enrage').setChoices(...this.enrageOptions).setRequired(true))
+            .addUserOption((option) => option.setName('trial').setDescription('Person to host for').setRequired(true))
             .addStringOption((option) => option.setName('message').setDescription('Add a Message').setRequired(false));
     }
 
@@ -45,11 +43,11 @@ export default class HostLearner extends BotInteraction {
 
         const mode: string = interaction.options.getString('mode', true);
         const message: string | null = interaction.options.getString('message', false);
-        const learner: User = interaction.options.getUser('learner', true);
+        const learner: User = interaction.options.getUser('trial', true);
 
-        const learnerHostChannel = await interaction.guild?.channels.fetch(this.client.channelIds.learnerHosts) as TextChannel;
+        const learnerHostChannel = await interaction.guild?.channels.fetch(this.client.channelIds.trialHosts) as TextChannel;
 
-        const success = await HostHandler.postHost(learnerHostChannel, mode, message, [learner.id], [interaction.user.id], null, 0);
+        const success = await HostHandler.postHost(learnerHostChannel, mode, message, [learner.id], [interaction.user.id], null, 2);
 
         const container = this.client.cv2.getContainerBuilder(success, "Host card creation");
         container.addTextDisplayComponents(builder => builder.setContent(success ? "Your host has been successfully created!" : "Your host could not be created!"));

--- a/src/interactions/trialteam/TrialLeaderboard.ts
+++ b/src/interactions/trialteam/TrialLeaderboard.ts
@@ -1,0 +1,51 @@
+import LeaderboardHandler from '../../modules/LeaderboardHandler';
+import BotInteraction from '../../types/BotInteraction';
+import { ChatInputCommandInteraction, MessageFlags, SlashCommandBuilder, TextChannel } from 'discord.js';
+
+export default class TrialLeaderboard extends BotInteraction {
+    get name() {
+        return 'trial-leaderboard';
+    }
+
+    get description() {
+        return 'Trial Leaderboards';
+    }
+
+    get permissions() {
+        return 'TRIAL_TEAM';
+    }
+
+    get timespanOptions() {
+        const timespanTypes: any = {
+            'Current Month': 'currentMonth',
+            'Last Month': 'lastMonth',
+            'Last 3 Months': 'lastThreeMonths',
+            'Current Year': 'currentYear',
+            'Last Year': 'lastYear',
+            'All Time': 'allTime',
+        }
+        const options: any = [];
+        Object.keys(timespanTypes).forEach((key: string) => {
+            options.push({ name: key, value: timespanTypes[key] })
+        })
+        return options;
+    }
+
+    get slashData() {
+        return new SlashCommandBuilder()
+            .setName(this.name)
+            .setDescription(this.description)
+            .addStringOption((option) => option.setName('timespan').setDescription('Time Span').addChoices(
+                ...this.timespanOptions
+            ).setRequired(false));
+    }
+
+    async run(interaction: ChatInputCommandInteraction) {
+        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+        const timespan: string | null = interaction.options.getString('timespan', false);
+
+        await LeaderboardHandler.postLeaderBoard(this.client, 2, interaction.channel as TextChannel, timespan ?? null)
+
+        await interaction.editReply('Leaderboard sent!');
+    }
+}

--- a/src/interactions/twitch/AddStreamer.ts
+++ b/src/interactions/twitch/AddStreamer.ts
@@ -1,4 +1,4 @@
-import { SlashCommandBuilder, ChatInputCommandInteraction } from "discord.js";
+import { SlashCommandBuilder, ChatInputCommandInteraction, MessageFlags } from "discord.js";
 import BotInteraction from "../../types/BotInteraction";
 import * as fs from 'fs/promises';
 import * as path from 'path';
@@ -59,7 +59,7 @@ export default class AddStreamer extends BotInteraction {
     async run(interaction: ChatInputCommandInteraction) {
         if (!interaction.inCachedGuild()) return;
 
-        await interaction.deferReply({ ephemeral: true });
+        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
         let userName = interaction.options.getString('username', true).toLowerCase();
         const discordUser = interaction.options.getUser('discord-user', true);

--- a/src/interactions/twitch/ListStreamers.ts
+++ b/src/interactions/twitch/ListStreamers.ts
@@ -1,4 +1,4 @@
-import { SlashCommandBuilder, ChatInputCommandInteraction, EmbedBuilder } from "discord.js";
+import { SlashCommandBuilder, ChatInputCommandInteraction, EmbedBuilder, MessageFlags } from "discord.js";
 import BotInteraction from "../../types/BotInteraction";
 import * as fs from 'fs/promises';
 import * as path from 'path';
@@ -45,7 +45,7 @@ export default class ListStreamers extends BotInteraction {
     }
 
     async run(interaction: ChatInputCommandInteraction) {
-        await interaction.deferReply({ ephemeral: true });
+        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
         const streamers = await readStreamers();
 

--- a/src/interactions/twitch/RemoveStreamer.ts
+++ b/src/interactions/twitch/RemoveStreamer.ts
@@ -1,4 +1,4 @@
-import { SlashCommandBuilder, ChatInputCommandInteraction, AutocompleteInteraction } from "discord.js";
+import { SlashCommandBuilder, ChatInputCommandInteraction, AutocompleteInteraction, MessageFlags } from "discord.js";
 import BotInteraction from "../../types/BotInteraction";
 import * as fs from 'fs/promises';
 import * as path from 'path';
@@ -64,7 +64,7 @@ export default class RemoveStreamer extends BotInteraction {
     async run(interaction: ChatInputCommandInteraction) {
         if (!interaction.inCachedGuild()) return;
 
-        await interaction.deferReply({ ephemeral: true });
+        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
         const userNameToRemove = interaction.options.getString('username', true);
 

--- a/src/interactions/twitch/StreamDashboard.ts
+++ b/src/interactions/twitch/StreamDashboard.ts
@@ -1,4 +1,4 @@
-import { SlashCommandBuilder } from 'discord.js';
+import { MessageFlags, SlashCommandBuilder } from 'discord.js';
 import BotInteraction from '../../types/BotInteraction';
 
 export default class StreamDashboard extends BotInteraction {
@@ -27,16 +27,16 @@ export default class StreamDashboard extends BotInteraction {
         try {
             const twitchHandler = this.client.twitchHandler;
             if (!twitchHandler) {
-                await interaction.reply({ content: 'Twitch handler not found.', ephemeral: true });
+                await interaction.reply({ content: 'Twitch handler not found.', flags: MessageFlags.Ephemeral });
                 return;
             }
 
             await (twitchHandler as any).updateContentCreatorsDashboard();
 
-            await interaction.reply({ content: 'Content creators dashboard has been created/updated!', ephemeral: true });
+            await interaction.reply({ content: 'Content creators dashboard has been created/updated!', flags: MessageFlags.Ephemeral });
         } catch (error) {
             console.error('Failed to create dashboard:', error);
-            await interaction.reply({ content: 'Failed to create the dashboard. Check the logs for details.', ephemeral: true });
+            await interaction.reply({ content: 'Failed to create the dashboard. Check the logs for details.', flags: MessageFlags.Ephemeral });
         }
     }
 }

--- a/src/modules/AutoTriggerHandler.ts
+++ b/src/modules/AutoTriggerHandler.ts
@@ -314,7 +314,8 @@ export default class AutoTriggerHandler {
                 const mediaGalleryBuilder = new MediaGalleryBuilder();
 
                 for (const [_, attachment] of message.attachments) {
-                    mediaGalleryBuilder.addItems(item => item.setURL(attachment.proxyURL));
+                    const newUrl = await this.client.util.reuploadImage(attachment.url);
+                    mediaGalleryBuilder.addItems(item => item.setURL(newUrl));
                 }
 
                 container.addMediaGalleryComponents(mediaGalleryBuilder);

--- a/src/modules/HostHandler.ts
+++ b/src/modules/HostHandler.ts
@@ -4,8 +4,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import TicketHandler from './TicketHandler';
 import ComponentsV2Utils from './ComponentsV2Utils';
-import { LearnerHour } from '../entity/LearnerHour';
-import { LearnerHourParticipation } from '../entity/LearnerHourParticipation';
+import { HostParticipation } from '../entity/HostParticipation';
 
 export default interface HostHandler { client: Bot; id: string; interaction: Interaction }
 
@@ -24,61 +23,115 @@ export default class HostHandler {
             return;
         }
 
-        if (id.startsWith("host_learner_post_")) {
-            this.handleLearnerHostPost(interaction, id.substring(18));
-            return;
-        }
-
         if (id.startsWith("host_post_")) {
             this.handleHostPost(interaction, id.substring(10));
             return;
         }
 
+        if (id.startsWith("host_learner_post_")) {
+            this.handleHostPostByType(interaction, id.substring(18), 0);
+            return;
+        }
+
         if (id.startsWith("host_learner_finish_")) {
-            this.handleHostLearnerFinish(interaction as ModalSubmitInteraction, id.substring(20));
+            this.handleHostFinishByType(interaction as ModalSubmitInteraction, id.substring(20), 0);
+        }
+
+        if (id.startsWith("host_lorebook_post_")) {
+            this.handleHostPostByType(interaction, id.substring(19), 1);
+            return;
+        }
+
+        if (id.startsWith("host_lorebook_finish_")) {
+            this.handleHostFinishByType(interaction as ModalSubmitInteraction, id.substring(21), 1);
+        }
+
+        if (id.startsWith("host_trial_post_")) {
+            this.handleHostPostByType(interaction, id.substring(16), 2);
+            return;
+        }
+
+        if (id.startsWith("host_trial_finish_")) {
+            this.handleHostFinishByType(interaction as ModalSubmitInteraction, id.substring(18), 2);
         }
 
         switch (id) {
-            case 'host_learner_select_user': this.handleLearnerHostUserselect(interaction as UserSelectMenuInteraction); break;
-            case 'host_learner_select_role': this.handleLearnerHostStringselect(interaction as StringSelectMenuInteraction); break;
-            case 'host_learner_submit_select': this.handleLearnerHostAssign(interaction); break;
-            case 'host_learner_finish': this.finishHost(interaction as ButtonInteraction<'cached'>); break;
-            case 'host_learner_disband': this.disbandHost(interaction); break;
+            case 'host_learner_select_user': this.handleHostUserselectByType(interaction as UserSelectMenuInteraction, 0); break;
+            case 'host_learner_select_role': this.handleHostStringselectByType(interaction as StringSelectMenuInteraction, 0); break;
+            case 'host_learner_select_type': this.handleHostStringselectByType(interaction as StringSelectMenuInteraction, 0); break;
+            case 'host_learner_submit_select': this.handleHostAssignByType(interaction, 0); break;
+            case 'host_learner_finish': this.finishHost(interaction as ButtonInteraction<'cached'>, 0); break;
+            case 'host_learner_disband': this.disbandHost(interaction, 0); break;
+            case 'host_learner_quickfinish': this.quickFinishHost(interaction, 0); break;
+
+            case 'host_lorebook_select_user': this.handleHostUserselectByType(interaction as UserSelectMenuInteraction, 1); break;
+            case 'host_lorebook_select_role': this.handleHostStringselectByType(interaction as StringSelectMenuInteraction, 1); break;
+            case 'host_lorebook_select_type': this.handleHostStringselectByType(interaction as StringSelectMenuInteraction, 1); break;
+            case 'host_lorebook_submit_select': this.handleHostAssignByType(interaction, 1); break;
+            case 'host_lorebook_finish': this.finishHost(interaction as ButtonInteraction<'cached'>, 1); break;
+            case 'host_lorebook_disband': this.disbandHost(interaction, 1); break;
+            case 'host_lorebook_quickfinish': this.quickFinishHost(interaction, 1); break;
+
+            case 'host_trial_select_user': this.handleHostUserselectByType(interaction as UserSelectMenuInteraction, 2); break;
+            case 'host_trial_select_role': this.handleHostStringselectByType(interaction as StringSelectMenuInteraction, 2); break;
+            case 'host_trial_select_type': this.handleHostStringselectByType(interaction as StringSelectMenuInteraction, 2); break;
+            case 'host_trial_submit_select': this.handleHostAssignByType(interaction, 2); break;
+            case 'host_trial_finish': this.finishHost(interaction as ButtonInteraction<'cached'>, 2); break;
+            case 'host_trial_disband': this.disbandHost(interaction, 2); break;
+            case 'host_trial_quickfinish': this.quickFinishHost(interaction, 2); break;
         }
     }
 
     //#region Modal Handlers
 
-    private async handleHostLearnerFinish(interaction: ModalSubmitInteraction, hostMessageId: string) {
+    private async handleHostFinishByType(interaction: ModalSubmitInteraction, hostMessageId: string, type: number) {
         await interaction.deferReply({ flags: MessageFlags.Ephemeral });
-        // disable Host
-        await HostHandler.disableHost(interaction.message!);
 
         // get current host card & clean it
         const message = await interaction.channel!.messages.fetch({
             limit: 1,
             before: interaction.message!.id
         });
-        const container = ComponentsV2Utils.cleanContainer(message!.first()!.components[0]);
+        const container: ContainerBuilder = ComponentsV2Utils.cleanContainer(message!.first()!.components[0]);
+        const controlContainer = ComponentsV2Utils.cleanContainer(interaction.message?.components[0]);
 
         let containerJson = JSON.stringify(container, null, 2);
+        let controlContainerJson = JSON.stringify(controlContainer, null, 2);
 
         // give points
         const hostData = HostHandler.getHostData(containerJson);
+        const hostData2 = HostHandler.getHostData(controlContainerJson);
+
         const users: string[] = (hostData[1] as string[]).map(x => x.slice(2, -1));
+        const hosts: string[] = (hostData2[2] as string[]).map(x => x.slice(2, -1));
+        const learners: string[] = (hostData2[3] as string[]).map(x => x.slice(2, -1));
 
         if (!users.includes(interaction.user.id)) {
             users.push(interaction.user.id);
         }
 
-        await this.saveLearnerHour(message!.first()!.url, interaction.user.id, users);
+        // make sure users dont contain the learners
+        const fillers = users.filter(x => !learners.includes(x) && !hosts.includes(x));
 
-        // post summary in #teachers-chat
+        //await this.saveLearnerHour(message!.first()!.url, interaction.user.id, users);
+        await HostHandler.saveHost(this.client, type, message?.first()?.url ?? null, hosts, fillers);
+
+        // post summary
+        const hostTypeLabel = type === 0 ? 'Learner Hour' : type === 1 ? 'Lore Book' : type === 2 ? 'Trial' : 'Undefined';
+        const attendingTypeLabel = type === 0 ? 'Learners' : type === 1 ? 'Participants' : type === 2 ? 'Trialees' : 'Undefined';
+
         const summary = interaction.fields.getTextInputValue("summary");
-        const participants = `## Participants:\n${users.map(x => `<@${x}>`).join('\n')}`;
+        const summaryContainer = this.client.cv2.getContainerBuilder(null, `${hostTypeLabel} hosted by <@${interaction.user.id}> - Summary`);
 
-        const summaryContainer = this.client.cv2.getContainerBuilder(null, `Learner Hour hosted by <@${interaction.user.id}> - Summary`);
-        summaryContainer.addTextDisplayComponents(t => t.setContent(participants)).addSeparatorComponents(s => s.setSpacing(SeparatorSpacingSize.Small));
+        const teachersText = `### Hosts:\n${hosts.map(x => `<@${x}>`).join('\n')}`;
+        const fillersText = `### Fillers:\n${fillers.map(x => `<@${x}>`).join('\n')}`;
+        const learnersText = `### ${attendingTypeLabel}:\n${learners.map(x => `<@${x}>`).join('\n')}`;
+
+        summaryContainer.addTextDisplayComponents(t => t.setContent(teachersText))
+                .addTextDisplayComponents(t => t.setContent(fillersText))
+                .addTextDisplayComponents(t => t.setContent(learnersText))
+                .addSeparatorComponents(s => s.setSpacing(SeparatorSpacingSize.Small));
+
         summaryContainer.addTextDisplayComponents(t => t.setContent(summary));
 
         const teacherChannel = await this.client.channels.fetch(this.client.channelIds.teachersChat) as TextChannel;
@@ -88,6 +141,9 @@ export default class HostHandler {
             allowedMentions: { "parse": [] }
         });
 
+        // disable Host
+        await HostHandler.disableHost(interaction.message!);
+
         await interaction.editReply('Learner hour finished!');
     }
 
@@ -95,34 +151,54 @@ export default class HostHandler {
 
     //#region Signup Handlers
 
-    private async handleLearnerHostUserselect(interaction: UserSelectMenuInteraction) {
+    private async handleHostUserselectByType(interaction: UserSelectMenuInteraction, type: number) {
         await interaction.deferUpdate();
 
         const userIds: string[] = interaction.values;
         const userIdSubmit: string = interaction.user.id;
 
-        this.client.tempSubmissionData?.set(`host_learner_user_${userIdSubmit}`, userIds);
+        this.client.tempSubmissionData?.set(`host_${type === 0 ? 'learner' : type === 1 ? 'lorebook' : type === 2 ? 'trial' : 'undefined'}_user_${userIdSubmit}`, userIds);
     }
 
-    private async handleLearnerHostStringselect(interaction: StringSelectMenuInteraction) {
+    private async handleHostStringselectByType(interaction: StringSelectMenuInteraction, type: number) {
         await interaction.deferUpdate();
 
         const roles: string[] = interaction.values;
         const userIdSubmit: string = interaction.user.id;
 
-        this.client.tempSubmissionData?.set(`host_learner_role_${userIdSubmit}`, roles);
+        if (interaction.customId === `host_${type === 0 ? 'learner' : type === 1 ? 'lorebook' : type === 2 ? 'trial' : 'undefined'}_select_role`) {
+            this.client.tempSubmissionData?.set(`host_${type === 0 ? 'learner' : type === 1 ? 'lorebook' : type === 2 ? 'trial' : 'undefined'}_role_${userIdSubmit}`, roles);
+        } else if (interaction.customId === `host_${type === 0 ? 'learner' : type === 1 ? 'lorebook' : type === 2 ? 'trial' : 'undefined'}_select_type`) {
+            this.client.tempSubmissionData?.set(`host_${type === 0 ? 'learner' : type === 1 ? 'lorebook' : type === 2 ? 'trial' : 'undefined'}_type_${userIdSubmit}`, roles);
+        }
     }
 
-    private async handleLearnerHostAssign(interaction: Interaction) {
+    private async handleHostAssignByType(interaction: Interaction, type: number) {
         if (!('deferReply' in interaction && 'editReply' in interaction && 'message' in interaction)) {
             return;
         }
 
         await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
-        //check if user is teacher, admin or owner
-        if (!await this.client.util.hasRolePermissions(this.client, ['teacher', 'admin', 'owner'], interaction)) {
-            return await interaction.editReply('This action can only be used by Teachers!');
+        if (type === 0) {
+            //check if user is teacher, admin or owner
+            if (!await this.client.util.hasRolePermissions(this.client, ['teacher', 'admin', 'owner'], interaction)) {
+                return await interaction.editReply('This action can only be used by Teachers!');
+            }
+        }
+
+        if (type === 1) {
+            //check if user is lore book crew, teacher, admin or owner
+            if (!await this.client.util.hasRolePermissions(this.client, ['lorebook', 'teacher', 'admin', 'owner'], interaction)) {
+                return await interaction.editReply('This action can only be used by Lore Book Crew and Teachers!');
+            }
+        }
+
+        if (type === 2) {
+            //check if user is trial team, admin or owner
+            if (!await this.client.util.hasRolePermissions(this.client, ['trialTeam', 'admin', 'owner'], interaction)) {
+                return await interaction.editReply('This action can only be used by Trial Team Members!');
+            }
         }
 
         const container = ComponentsV2Utils.cleanContainer(interaction.message!.components[0]);
@@ -130,9 +206,12 @@ export default class HostHandler {
         //check submissionData
         const userIdSubmit: string = interaction.user.id;
 
-        if (this.client.tempSubmissionData?.has(`host_learner_role_${userIdSubmit}`) && this.client.tempSubmissionData?.has(`host_learner_user_${userIdSubmit}`)) {
-            const user = this.client.tempSubmissionData.get(`host_learner_user_${userIdSubmit}`)[0];
-            const role = this.client.tempSubmissionData.get(`host_learner_role_${userIdSubmit}`)[0];
+        if (this.client.tempSubmissionData?.has(`host_${type === 0 ? 'learner' : type === 1 ? 'lorebook' : type === 2 ? 'trial' : 'undefined'}_role_${userIdSubmit}`)
+            && this.client.tempSubmissionData?.has(`host_${type === 0 ? 'learner' : type === 1 ? 'lorebook' : type === 2 ? 'trial' : 'undefined'}_user_${userIdSubmit}`)
+            && this.client.tempSubmissionData?.has(`host_${type === 0 ? 'learner' : type === 1 ? 'lorebook' : type === 2 ? 'trial' : 'undefined'}_type_${userIdSubmit}`)) {
+            const user = this.client.tempSubmissionData.get(`host_${type === 0 ? 'learner' : type === 1 ? 'lorebook' : type === 2 ? 'trial' : 'undefined'}_user_${userIdSubmit}`)[0];
+            const roles = this.client.tempSubmissionData.get(`host_${type === 0 ? 'learner' : type === 1 ? 'lorebook' : type === 2 ? 'trial' : 'undefined'}_role_${userIdSubmit}`);
+            const typeSelect = this.client.tempSubmissionData.get(`host_${type === 0 ? 'learner' : type === 1 ? 'lorebook' : type === 2 ? 'trial' : 'undefined'}_type_${userIdSubmit}`)[0];
 
             // fetch previous message, that contains the host
             const message = await interaction.channel!.messages.fetch({
@@ -141,11 +220,45 @@ export default class HostHandler {
             });
 
             if (message) {
-                await this.handleHostAssign(interaction, role, message.first()!, user);
+                for (const role of roles) {
+                    await this.handleHostAssign(interaction, role, message.first()!, user);
+                }
+
+                let containerJson = JSON.stringify(container, null, 2);
+
+                if (typeSelect === 'host' || typeSelect === 'learner') {
+                    // update the control-panel
+                    const containerData = HostHandler.getHostData(containerJson);
+                    const data: Map<string, string> = containerData[0] as Map<string, string>;
+                    const userMention: string = `<@${user}>`;
+
+                    if (data.get(typeSelect)?.includes(userMention)) {
+                        // remove teacher / learner from host
+                        const oldValue = `${HostHandler.keyToLabel(typeSelect)}: ${data.get(typeSelect)}`.trim();
+                        const newValue = oldValue.replace(userMention, '');
+                        containerJson = containerJson.replace(oldValue, newValue);
+                    } else {
+                        // add teacher / learner to host
+                        const oldValue = `${HostHandler.keyToLabel(typeSelect)}: ${data.get(typeSelect) ? data.get(typeSelect): ''}`.trim();
+                        const newValue = `${oldValue} ${userMention}`;
+
+                        //edge case: card CAN not contain a learner yet, but always has a host
+                        if (typeSelect === 'learner' && !containerJson.includes('Learner:')) {
+                            containerJson = containerJson.replace('Host:', `${newValue}\\nHost:`);
+                        } else {
+                            containerJson = containerJson.replace(oldValue, newValue);
+                        }
+                    }
+                }
+
+                const newContainer = JSON.parse(containerJson);
+
+                const containers = [];
+                containers.push(newContainer);
 
                 // Reset Panel
                 return await interaction.message!.edit({
-                    components: [container],
+                    components: containers,
                     flags: MessageFlags.IsComponentsV2,
                     allowedMentions: { 'parse': [] }
                 });
@@ -221,7 +334,7 @@ export default class HostHandler {
 
     //#region Posting Handlers
 
-    private async handleLearnerHostPost(interaction: Interaction, id: string) {
+    private async handleHostPostByType(interaction: Interaction, id: string, type: number) {
         if (!('deferReply' in interaction && 'editReply' in interaction && 'message' in interaction)) {
             return;
         }
@@ -237,24 +350,43 @@ export default class HostHandler {
         const learner = await TicketHandler.findTicketOpener(interaction.channel as TextChannel, this.client);
 
         //grab learner hosts channel
-        const learnerHostChannel = await interaction.guild?.channels.fetch(this.client.channelIds.learnerHosts) as TextChannel;
+        const hostChannel = type === 0 ? await interaction.guild?.channels.fetch(this.client.channelIds.learnerHosts) as TextChannel
+                            : type === 1 ? await interaction.guild?.channels.fetch(this.client.channelIds.learnerHosts) as TextChannel
+                            : type === 2 ? await interaction.guild?.channels.fetch(this.client.channelIds.learnerHosts) as TextChannel // TODO - Trials
+                            : await interaction.guild?.channels.fetch(this.client.channelIds.learnerHosts) as TextChannel;
 
         //set up the host card in it
-        await HostHandler.postHost(learnerHostChannel!, id, null, learner, interaction.user.id);
+        await HostHandler.postHost(hostChannel!, id, null, learner ? [learner] : null, [interaction.user.id], null, type);
 
-        return await interaction.editReply('Host card successfully created');
+        return await interaction.editReply(`Host card successfully created! Head over to <#${hostChannel.id}> to find your host.`);
     }
 
-    private async disbandHost(interaction: Interaction) {
+    private async disbandHost(interaction: Interaction, type: number) {
         if (!('editReply' in interaction && 'message' in interaction)) {
             return;
         }
 
         await interaction.deferReply();
 
-        //check if user is teacher, admin or owner
-        if (!await this.client.util.hasRolePermissions(this.client, ['teacher', 'admin', 'owner'], interaction)) {
-            return await interaction.editReply('This action can only be used by Teachers!');
+        if (type === 0) {
+            //check if user is teacher, admin or owner
+            if (!await this.client.util.hasRolePermissions(this.client, ['teacher', 'admin', 'owner'], interaction)) {
+                return await interaction.editReply('This action can only be used by Teachers!');
+            }
+        }
+
+        if (type === 1) {
+            //check if user is lore book crew, teacher, admin or owner
+            if (!await this.client.util.hasRolePermissions(this.client, ['lorebook', 'teacher', 'admin', 'owner'], interaction)) {
+                return await interaction.editReply('This action can only be used by Lore Book Crew and Teachers!');
+            }
+        }
+
+        if (type === 2) {
+            //check if user is trial team, admin or owner
+            if (!await this.client.util.hasRolePermissions(this.client, ['trialTeam', 'admin', 'owner'], interaction)) {
+                return await interaction.editReply('This action can only be used by Trial Team Members!');
+            }
         }
 
         if (await HostHandler.disableHost(interaction.message!)) {
@@ -264,25 +396,42 @@ export default class HostHandler {
         }
     }
 
-    private async finishHost(interaction: ButtonInteraction<'cached'>) {
-        //check if user is teacher, admin or owner
-        if (!await this.client.util.hasRolePermissions(this.client, ['teacher', 'admin', 'owner'], interaction)) {
-            return await interaction.reply('This action can only be used by Teachers!');
+    private async finishHost(interaction: ButtonInteraction<'cached'>, type: number) {
+        if (type === 0) {
+            //check if user is teacher, admin or owner
+            if (!await this.client.util.hasRolePermissions(this.client, ['teacher', 'admin', 'owner'], interaction)) {
+                return await interaction.editReply('This action can only be used by Teachers!');
+            }
+        }
+
+        if (type === 1) {
+            //check if user is lore book crew, teacher, admin or owner
+            if (!await this.client.util.hasRolePermissions(this.client, ['lorebook', 'teacher', 'admin', 'owner'], interaction)) {
+                return await interaction.editReply('This action can only be used by Lore Book Crew and Teachers!');
+            }
+        }
+
+        if (type === 2) {
+            //check if user is trial team, admin or owner
+            if (!await this.client.util.hasRolePermissions(this.client, ['trialTeam', 'admin', 'owner'], interaction)) {
+                return await interaction.editReply('This action can only be used by Trial Team Members!');
+            }
         }
 
         const modal = new ModalBuilder()
-            .setCustomId(`host_learner_finish_${interaction.message.id}`)
-            .setTitle('Learner Hour Summary');
+            .setCustomId(`host_${type === 0 ? 'learner' : type === 1 ? 'lorebook' : type === 2 ? 'trial' : 'undefined'}_finish_${interaction.message.id}`)
+            .setTitle('Summary');
 
         const summaryInput = new TextInputBuilder()
             .setCustomId('summary')
-            .setLabel('Please summarize the learner hour')
             .setStyle(TextInputStyle.Paragraph)
             .setRequired(true);
 
-        const firstRow = new ActionRowBuilder<TextInputBuilder>().addComponents(summaryInput);
+        modal.addLabelComponents(label => label
+            .setLabel('Please summarize the hour')
+            .setTextInputComponent(summaryInput)
+        );
 
-        modal.addComponents(firstRow);
         await interaction.showModal(modal);
     }
 
@@ -302,7 +451,126 @@ export default class HostHandler {
 
         await HostHandler.postHost(interaction.channel! as TextChannel, id, null);
 
-        return await interaction.editReply('Host card successfully created');
+        return await interaction.editReply(`Host card successfully created! Head over to <#${interaction.channel!.id}> to find your host.`);
+    }
+
+    private async quickFinishHost(interaction: Interaction, type: number) {
+        if (!('deferReply' in interaction && 'editReply' in interaction && 'showModal' in interaction && 'awaitModalSubmit' in interaction)) {
+            return;
+        }
+
+        if (type === 0) {
+            //check if user is teacher, admin or owner
+            if (!await this.client.util.hasRolePermissions(this.client, ['teacher', 'admin', 'owner'], interaction)) {
+                return await interaction.editReply('This action can only be used by Teachers!');
+            }
+        }
+
+        if (type === 1) {
+            //check if user is lore book crew, teacher, admin or owner
+            if (!await this.client.util.hasRolePermissions(this.client, ['lorebook', 'teacher', 'admin', 'owner'], interaction)) {
+                return await interaction.editReply('This action can only be used by Lore Book Crew and Teachers!');
+            }
+        }
+
+        if (type === 2) {
+            //check if user is trial team, admin or owner
+            if (!await this.client.util.hasRolePermissions(this.client, ['trialTeam', 'admin', 'owner'], interaction)) {
+                return await interaction.editReply('This action can only be used by Trial Team Members!');
+            }
+        }
+
+        const modal = new ModalBuilder()
+            .setCustomId('quickfinish-host-modal')
+            .setTitle('finish host');
+
+        // Hosts
+        const hostSelect = new UserSelectMenuBuilder()
+            .setCustomId('host_select')
+            .setRequired(true)
+            .setMaxValues(5);
+
+        modal.addLabelComponents(label => label.setLabel('Who were hosting?').setUserSelectMenuComponent(hostSelect));
+
+        // Fillers
+        const fillerSelect = new UserSelectMenuBuilder()
+            .setCustomId('filler_select')
+            .setRequired(true)
+            .setMaxValues(5);
+
+        modal.addLabelComponents(label => label.setLabel('Who were filling?').setUserSelectMenuComponent(fillerSelect));
+
+        // Fillers
+        const learnerSelect = new UserSelectMenuBuilder()
+            .setCustomId('learner_select')
+            .setRequired(true)
+            .setMaxValues(5);
+
+        modal.addLabelComponents(label => label.setLabel('Who were learning / getting book / trialing?').setUserSelectMenuComponent(learnerSelect));
+
+        // Summary
+        const summaryInput = new TextInputBuilder()
+            .setCustomId('summary')
+            .setStyle(TextInputStyle.Paragraph)
+            .setRequired(true)
+            .setMaxLength(4000);
+
+        modal.addLabelComponents(label => label.setLabel('Summarize the hour').setTextInputComponent(summaryInput));
+
+        await interaction.showModal(modal);
+
+        const filter = (i: ModalSubmitInteraction) => i.customId === 'quickfinish-host-modal' && i.user.id === interaction.user.id;
+
+        try {
+            const modalInteraction = await interaction.awaitModalSubmit({ filter, time: 900_000 }); // 15 minutes
+
+            const hostSelect = modalInteraction.fields.getSelectedUsers('host_select', true);
+            const fillerSelect = modalInteraction.fields.getSelectedUsers('filler_select', true);
+            const learnerSelect = modalInteraction.fields.getSelectedUsers('learner_select', true);
+            const summaryInput = modalInteraction.fields.getTextInputValue('summary');
+
+            const hostTypeLabel = type === 0 ? 'Learner Hour' : type === 1 ? 'Lore Book' : type === 2 ? 'Trial' : 'Undefined';
+            const attendingTypeLabel = type === 0 ? 'Learners' : type === 1 ? 'Participants' : type === 2 ? 'Trialees' : 'Undefined';
+
+            const container = this.client.cv2.getContainerBuilder(null, `${hostTypeLabel} hosted by <@${interaction.user.id}> - Summary`);
+            const hosts = `### Hosts:\n${hostSelect.map(x => `<@${x.id}>`).join('\n')}`;
+            const hostsArray = hostSelect.map(x => x.id);
+            const fillers = `### Fillers:\n${fillerSelect.map(x => `<@${x.id}>`).join('\n')}`;
+            const fillersArray = fillerSelect.map(x => x.id);
+            const learners = `### ${attendingTypeLabel}:\n${learnerSelect.map(x => `<@${x.id}>`).join('\n')}`;
+            const learnersArray = learnerSelect.map(x => x.id);
+
+            container.addTextDisplayComponents(t => t.setContent(hosts))
+                    .addTextDisplayComponents(t => t.setContent(fillers))
+                    .addTextDisplayComponents(t => t.setContent(learners))
+                    .addSeparatorComponents(s => s.setSpacing(SeparatorSpacingSize.Small));
+
+            container.addTextDisplayComponents(t => t.setContent(summaryInput));
+
+            // depending on type send summary to different channel
+            const targetChannel = type === 0 ? await this.client.channels.fetch(this.client.channelIds.teachersChat) as TextChannel
+                                : type === 1 ? await this.client.channels.fetch(this.client.channelIds.teachersChat) as TextChannel
+                                : type === 2 ? await this.client.channels.fetch(this.client.channelIds.trialLounge) as TextChannel
+                                : await this.client.channels.fetch(this.client.channelIds.teachersChat) as TextChannel;
+
+            await targetChannel.send({
+                components: [container],
+                flags: MessageFlags.IsComponentsV2,
+                allowedMentions: { "parse": [] }
+            });
+
+            if (type === 1) {
+                for (let index = 0; index < learnersArray.length; index++) {
+                    await HostHandler.saveHost(this.client, type, null, hostsArray, fillersArray);
+                }
+            } else {
+                await HostHandler.saveHost(this.client, type, null, hostsArray, fillersArray);
+            }
+
+            await modalInteraction.reply({ content: `Host finished!`, flags: MessageFlags.Ephemeral });
+        } catch (err) {
+            console.error('quickFinishhost error:', err);
+        }
     }
 
     //#endregion
@@ -312,15 +580,38 @@ export default class HostHandler {
     private static getHostData(hostJson: string) {
         // extract data from current host card
         const data = new Map<string, string>();
-        const regex = /([\w ]+):\s*(`empty`|<@!?[0-9]+>)(?:\s*&\s*(`empty`|<@!?[0-9]+>))*/g;
+        const hosts: string[] = [];
+        const learners: string[] = [];
+
+        const regex = /([\w ]+):\s*(`empty`|<@!?[0-9]+>)(?:\s*&?\s*(`empty`|<@!?[0-9]+>))*/g;
         for (const match of hostJson.matchAll(regex)) {
             let label = match[1].trim();
             const value = match[2].trim();
+            const value2 = match[3]?.trim();
+            const value3 = match[4]?.trim();
+            const value4 = match[5]?.trim();
+            const value5 = match[6]?.trim();
 
             if (label.startsWith('n')) label = label.substring(1);
             label = label.replaceAll(" ", "").toLowerCase();
 
             data.set(label, value);
+
+            if (label === 'host') {
+                 if (!hosts.includes(value)) hosts.push(value);
+                 if (value2 && !hosts.includes(value2)) hosts.push(value2);
+                 if (value3 && !hosts.includes(value3)) hosts.push(value3);
+                 if (value4 && !hosts.includes(value4)) hosts.push(value4);
+                 if (value5 && !hosts.includes(value5)) hosts.push(value5);
+            }
+
+            if (label === 'learner' || label === 'trialee' || label === 'participant') {
+                if (!learners.includes(value)) learners.push(value);
+                 if (value2 && !learners.includes(value2)) learners.push(value2);
+                 if (value3 && !learners.includes(value3)) learners.push(value3);
+                 if (value4 && !learners.includes(value4)) learners.push(value4);
+                 if (value5 && !learners.includes(value5)) learners.push(value5);
+            }
         }
 
         // check if already 5 distinct people are signed up
@@ -334,7 +625,7 @@ export default class HostHandler {
             }
         }
 
-        return [data, users];
+        return [data, users, hosts, learners];
     }
 
     private static async disableHost(hostMessage: Message<boolean>): Promise<boolean> {
@@ -415,12 +706,20 @@ export default class HostHandler {
                 return "Glyphs";
             case "backupglyphs":
                 return "Backup Glyphs";
+            case "host":
+                return "Host";
+            case "learner":
+                return "Learner";
+            case "trialee":
+                return "Trialee";
+            case "participant":
+                return "Participant";
             default:
                 return "";
         }
     }
 
-    public static async postHost(channel: TextChannel, mode: string, message: string | null, user: string | null = null, host: string | null = null, time: string | null = null): Promise<boolean> {
+    public static async postHost(channel: TextChannel, mode: string, message: string | null, users: string[] | null = null, hosts: string[] | null = null, time: string | null = null, type: number = -1): Promise<boolean> {
         const hostJson = this.loadHostConfig(mode, message);
 
         if (hostJson) {
@@ -430,28 +729,28 @@ export default class HostHandler {
                 { components: [hostContainer], flags: MessageFlags.IsComponentsV2, allowedMentions: { "parse": [] } }
             );
 
-            if (host !== null) {
+            if (hosts !== null) {
                 const teacherContainer = new ContainerBuilder()
                     .setAccentColor(10454367)
-                    .addTextDisplayComponents(builder => builder.setContent('Learner Hour Control Panel'))
+                    .addTextDisplayComponents(builder => builder.setContent(`${type === 0 ? 'Learner Hour' : type === 1 ? 'Lore Book Kill' : type === 2 ? 'Trial' : 'Undefined'} Control Panel`))
                     .addSeparatorComponents(separator => separator.setSpacing(SeparatorSpacingSize.Small));
 
                 let text = '';
 
-                if (time) text += `**Time:** <t:${time}:F>\n`;
-                if (user) text += `**Learner:** <@${user}>\n`;
-                text += `**Host:** <@${host}>`;
+                if (time) text += `Time: <t:${time}:F>\n`;
+                if (users) text += `${type === 0 ? 'Learner' : type === 1 ? 'Participant' : type === 2 ? 'Trialee' : 'Undefined'}: <@${users.join('>, <@')}>\n`;
+                text += `Host: <@${hosts?.join('>, <@')}>`;
 
                 teacherContainer.addTextDisplayComponents(builder => builder.setContent(text)).addSeparatorComponents(separator => separator.setSpacing(SeparatorSpacingSize.Small));
 
                 // Disable Buttons:
                 const finishButton = new ButtonBuilder()
-                    .setCustomId('host_learner_finish')
+                    .setCustomId(`host_${type === 0 ? 'learner' : type === 1 ? 'lorebook' : type === 2 ? 'trial' : 'undefined'}_finish`)
                     .setLabel('Finish')
                     .setStyle(ButtonStyle.Success);
 
                 const disbandButton = new ButtonBuilder()
-                    .setCustomId('host_learner_disband')
+                    .setCustomId(`host_${type === 0 ? 'learner' : type === 1 ? 'lorebook' : type === 2 ? 'trial' : 'undefined'}_disband`)
                     .setLabel('Disband')
                     .setStyle(ButtonStyle.Danger);
 
@@ -459,7 +758,7 @@ export default class HostHandler {
 
                 //doesnt work bc of 40 components limit
                 const userSelect = new UserSelectMenuBuilder()
-                    .setCustomId('host_learner_select_user')
+                    .setCustomId(`host_${type === 0 ? 'learner' : type === 1 ? 'lorebook' : type === 2 ? 'trial' : 'undefined'}_select_user`)
                     .setPlaceholder('Select a user to sign up');
 
                 const roleOptions = [
@@ -487,15 +786,28 @@ export default class HostHandler {
                 }
 
                 const roleSelect = new StringSelectMenuBuilder()
-                    .setCustomId('host_learner_select_role')
+                    .setCustomId(`host_${type === 0 ? 'learner' : type === 1 ? 'lorebook' : type === 2 ? 'trial' : 'undefined'}_select_role`)
                     .setPlaceholder('Select a role to sign the user up')
-                    .addOptions(roleOptions);
+                    .addOptions(roleOptions)
+                    .setMaxValues(5);
+
+                const typeOptions = [
+                    new StringSelectMenuOptionBuilder().setLabel('Host').setValue('host'),
+                    new StringSelectMenuOptionBuilder().setLabel('Filler').setValue('filler'),
+                    new StringSelectMenuOptionBuilder().setLabel(`${type === 0 ? 'Learner' : type === 1 ? 'Participant' : type === 2 ? 'Trialee' : 'Undefined'}`).setValue('learner'),
+                ];
+
+                const typeSelect = new StringSelectMenuBuilder()
+                    .setCustomId(`host_${type === 0 ? 'learner' : type === 1 ? 'lorebook' : type === 2 ? 'trial' : 'undefined'}_select_type`)
+                    .setPlaceholder('Select a type to sign the user up')
+                    .addOptions(typeOptions);
 
                 teacherContainer.addActionRowComponents(new ActionRowBuilder<UserSelectMenuBuilder>().addComponents(userSelect));
                 teacherContainer.addActionRowComponents(new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(roleSelect));
+                teacherContainer.addActionRowComponents(new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(typeSelect));
 
                 const submitSelectButton = new ButtonBuilder()
-                    .setCustomId('host_learner_submit_select')
+                    .setCustomId(`host_${type === 0 ? 'learner' : type === 1 ? 'lorebook' : type === 2 ? 'trial' : 'undefined'}_submit_select`)
                     .setLabel('Submit Assign')
                     .setStyle(ButtonStyle.Primary);
 
@@ -557,44 +869,39 @@ export default class HostHandler {
 
     //#region Database
 
-    //#region Learners
+    public static async saveHost(client: Bot, type: number, link: string | null, hosts: string[], participants: string[]): Promise<void> {
+        const { dataSource } = client;
+        const hostParticipationRepository = dataSource.getRepository(HostParticipation);
 
-    private async saveLearnerHour(link: string, host: string, participants: string[]): Promise<void> {
-        const { dataSource } = this.client;
-        const learnerHourRepository = dataSource.getRepository(LearnerHour);
-        const learnerHourParticipationRepository = dataSource.getRepository(LearnerHourParticipation);
+        const hostParticipants: HostParticipation[] = [];
 
-        const learnerHour = new LearnerHour();
-        learnerHour.host = host;
-        learnerHour.link = link;
-
-        // add all participants
-        const learnerHourParticipants: LearnerHourParticipation[] = [];
-        for (const participant of participants) {
-            const learnerHourParticipation = new LearnerHourParticipation();
-            learnerHourParticipation.participant = participant;
-            learnerHourParticipation.learnerHour = learnerHour;
-            learnerHourParticipants.push(learnerHourParticipation);
+        // add all hosts
+        for (const host of hosts) {
+            const hostParticipation = new HostParticipation();
+            hostParticipation.host = 1;
+            hostParticipation.participate = 1;
+            if (link) hostParticipation.link = link;
+            hostParticipation.type = type;
+            hostParticipation.user = host;
+            hostParticipants.push(hostParticipation);
         }
 
-        // if host is not in list, add them aswell
-        if (!participants.includes(host)) {
-            const learnerHourParticipation = new LearnerHourParticipation();
-            learnerHourParticipation.participant = host;
-            learnerHourParticipation.learnerHour = learnerHour;
-            learnerHourParticipants.push(learnerHourParticipation);
+        // add all fillers
+        for (const filler of participants) {
+            if (hosts.some(x => x === filler)) {
+                continue;
+            }
+            const hostParticipation = new HostParticipation();
+            hostParticipation.host = 0;
+            hostParticipation.participate = 1;
+            if (link) hostParticipation.link = link;
+            hostParticipation.type = type;
+            hostParticipation.user = filler;
+            hostParticipants.push(hostParticipation);
         }
 
-        learnerHour.participants = learnerHourParticipants;
-
-        await learnerHourRepository.save(learnerHour);
-        await learnerHourParticipationRepository.save(learnerHourParticipants);
+        await hostParticipationRepository.save(hostParticipants);
     }
-
-    //#endregion
-
-    //#region Trials
-    //#endregion
 
     //#endregion
 }

--- a/src/modules/HostHandler.ts
+++ b/src/modules/HostHandler.ts
@@ -134,8 +134,12 @@ export default class HostHandler {
 
         summaryContainer.addTextDisplayComponents(t => t.setContent(summary));
 
-        const teacherChannel = await this.client.channels.fetch(this.client.channelIds.teachersChat) as TextChannel;
-        await teacherChannel.send({
+        const targetChannel = type === 0 ? await this.client.channels.fetch(this.client.channelIds.teachersChat) as TextChannel
+                                : type === 1 ? await this.client.channels.fetch(this.client.channelIds.teachersChat) as TextChannel
+                                : type === 2 ? await this.client.channels.fetch(this.client.channelIds.trialLounge) as TextChannel
+                                : await this.client.channels.fetch(this.client.channelIds.teachersChat) as TextChannel;
+
+        await targetChannel.send({
             components: [summaryContainer],
             flags: MessageFlags.IsComponentsV2,
             allowedMentions: { "parse": [] }
@@ -243,7 +247,10 @@ export default class HostHandler {
                         const newValue = `${oldValue} ${userMention}`;
 
                         //edge case: card CAN not contain a learner yet, but always has a host
-                        if (typeSelect === 'learner' && !containerJson.includes('Learner:')) {
+                        if ((typeSelect === 'learner' && !containerJson.includes('Learner:'))
+                            || (typeSelect === 'participant' && !containerJson.includes('Participant:'))
+                            || (typeSelect === 'trialee' && !containerJson.includes('Trialee:'))
+                         ) {
                             containerJson = containerJson.replace('Host:', `${newValue}\\nHost:`);
                         } else {
                             containerJson = containerJson.replace(oldValue, newValue);
@@ -341,18 +348,34 @@ export default class HostHandler {
 
         await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
-        //check if user is teacher, admin or owner
-        if (!await this.client.util.hasRolePermissions(this.client, ['teacher', 'admin', 'owner'], interaction)) {
-            return await interaction.editReply('This action can only be used by Teachers!');
+        if (type === 0) {
+            //check if user is teacher, admin or owner
+            if (!await this.client.util.hasRolePermissions(this.client, ['teacher', 'admin', 'owner'], interaction)) {
+                return await interaction.editReply('This action can only be used by Teachers!');
+            }
         }
 
-        //find learner from learner ticket
+        if (type === 1) {
+            //check if user is lore book crew, teacher, admin or owner
+            if (!await this.client.util.hasRolePermissions(this.client, ['lorebook', 'teacher', 'admin', 'owner'], interaction)) {
+                return await interaction.editReply('This action can only be used by Lore Book Crew and Teachers!');
+            }
+        }
+
+        if (type === 2) {
+            //check if user is trial team, admin or owner
+            if (!await this.client.util.hasRolePermissions(this.client, ['trialTeam', 'admin', 'owner'], interaction)) {
+                return await interaction.editReply('This action can only be used by Trial Team Members!');
+            }
+        }
+
+        //find from ticket
         const learner = await TicketHandler.findTicketOpener(interaction.channel as TextChannel, this.client);
 
-        //grab learner hosts channel
+        //grab hosts channel
         const hostChannel = type === 0 ? await interaction.guild?.channels.fetch(this.client.channelIds.learnerHosts) as TextChannel
                             : type === 1 ? await interaction.guild?.channels.fetch(this.client.channelIds.learnerHosts) as TextChannel
-                            : type === 2 ? await interaction.guild?.channels.fetch(this.client.channelIds.learnerHosts) as TextChannel // TODO - Trials
+                            : type === 2 ? await interaction.guild?.channels.fetch(this.client.channelIds.trialHosts) as TextChannel
                             : await interaction.guild?.channels.fetch(this.client.channelIds.learnerHosts) as TextChannel;
 
         //set up the host card in it
@@ -559,7 +582,7 @@ export default class HostHandler {
                 allowedMentions: { "parse": [] }
             });
 
-            if (type === 1) {
+            if (type === 0 || type === 1) {
                 for (let index = 0; index < learnersArray.length; index++) {
                     await HostHandler.saveHost(this.client, type, null, hostsArray, fillersArray);
                 }

--- a/src/modules/InteractionHandler.ts
+++ b/src/modules/InteractionHandler.ts
@@ -167,7 +167,7 @@ export default class InteractionHandler extends EventEmitter {
                             return await interaction.reply({ content: 'You do not have permissions to run this command. This incident has been logged.', flags: MessageFlags.Ephemeral });
                         }
                         break;
-                    case 'TRIALTEAM':
+                    case 'TRIAL_TEAM':
                         if (!(await this.client.util.hasRolePermissions(this.client, ['trialTeam', 'admin', 'owner'], interaction))) {
                             this.client.logger.log({
                                 message: `Attempted restricted permissions. { command: ${command.name}, user: ${interaction.user.username}, channel: ${interaction.channel} }`,

--- a/src/modules/InteractionHandler.ts
+++ b/src/modules/InteractionHandler.ts
@@ -1,5 +1,5 @@
 import { Dirent, readdirSync } from 'fs';
-import { EmbedBuilder, Collection, Interaction } from 'discord.js';
+import { EmbedBuilder, Collection, Interaction, MessageFlags } from 'discord.js';
 import Bot from '../Bot';
 import BotInteraction from '../types/BotInteraction';
 import ButtonHandler from './ButtonHandler';
@@ -121,7 +121,7 @@ export default class InteractionHandler extends EventEmitter {
                                 message: `Attempted restricted permissions. { command: ${command.name}, user: ${interaction.user.username}, channel: ${interaction.channel} }`,
                                 handler: this.constructor.name,
                             }, true);
-                            return await interaction.reply({ content: 'You do not have permissions to run this command. This incident has been logged.', ephemeral: true });
+                            return await interaction.reply({ content: 'You do not have permissions to run this command. This incident has been logged.', flags: MessageFlags.Ephemeral });
                         }
                         break;
                     case 'OWNER':
@@ -130,7 +130,7 @@ export default class InteractionHandler extends EventEmitter {
                                 message: `Attempted restricted permissions. { command: ${command.name}, user: ${interaction.user.username}, channel: ${interaction.channel} }`,
                                 handler: this.constructor.name,
                             }, true);
-                            return await interaction.reply({ content: 'You do not have permissions to run this command. This incident has been logged.', ephemeral: true });
+                            return await interaction.reply({ content: 'You do not have permissions to run this command. This incident has been logged.', flags: MessageFlags.Ephemeral });
                         }
                     case 'ADMIN':
                         if (!(await this.client.util.hasRolePermissions(this.client, ['admin', 'owner'], interaction))) {
@@ -138,7 +138,7 @@ export default class InteractionHandler extends EventEmitter {
                                 message: `Attempted restricted permissions. { command: ${command.name}, user: ${interaction.user.username}, channel: ${interaction.channel} }`,
                                 handler: this.constructor.name,
                             }, true);
-                            return await interaction.reply({ content: 'You do not have permissions to run this command. This incident has been logged.', ephemeral: true });
+                            return await interaction.reply({ content: 'You do not have permissions to run this command. This incident has been logged.', flags: MessageFlags.Ephemeral });
                         }
                     case 'EDITOR':
                         if (!(await this.client.util.hasRolePermissions(this.client, ['editor', 'admin', 'owner'], interaction))) {
@@ -146,7 +146,34 @@ export default class InteractionHandler extends EventEmitter {
                                 message: `Attempted restricted permissions. { command: ${command.name}, user: ${interaction.user.username}, channel: ${interaction.channel} }`,
                                 handler: this.constructor.name,
                             }, true);
-                            return await interaction.reply({ content: 'You do not have permissions to run this command. This incident has been logged.', ephemeral: true });
+                            return await interaction.reply({ content: 'You do not have permissions to run this command. This incident has been logged.', flags: MessageFlags.Ephemeral });
+                        }
+                        break;
+                    case 'TEACHER':
+                        if (!(await this.client.util.hasRolePermissions(this.client, ['teacher', 'admin', 'owner'], interaction))) {
+                            this.client.logger.log({
+                                message: `Attempted restricted permissions. { command: ${command.name}, user: ${interaction.user.username}, channel: ${interaction.channel} }`,
+                                handler: this.constructor.name,
+                            }, true);
+                            return await interaction.reply({ content: 'You do not have permissions to run this command. This incident has been logged.', flags: MessageFlags.Ephemeral });
+                        }
+                        break;
+                    case 'LOREBOOK':
+                        if (!(await this.client.util.hasRolePermissions(this.client, ['lorebook', 'teacher', 'admin', 'owner'], interaction))) {
+                            this.client.logger.log({
+                                message: `Attempted restricted permissions. { command: ${command.name}, user: ${interaction.user.username}, channel: ${interaction.channel} }`,
+                                handler: this.constructor.name,
+                            }, true);
+                            return await interaction.reply({ content: 'You do not have permissions to run this command. This incident has been logged.', flags: MessageFlags.Ephemeral });
+                        }
+                        break;
+                    case 'TRIALTEAM':
+                        if (!(await this.client.util.hasRolePermissions(this.client, ['trialTeam', 'admin', 'owner'], interaction))) {
+                            this.client.logger.log({
+                                message: `Attempted restricted permissions. { command: ${command.name}, user: ${interaction.user.username}, channel: ${interaction.channel} }`,
+                                handler: this.constructor.name,
+                            }, true);
+                            return await interaction.reply({ content: 'You do not have permissions to run this command. This incident has been logged.', flags: MessageFlags.Ephemeral });
                         }
                         break;
                     default:
@@ -179,7 +206,7 @@ export default class InteractionHandler extends EventEmitter {
         }
 
         if (interaction.isStringSelectMenu() && interaction.inCachedGuild()) {
-            if (interaction.customId.startsWith('host_learner_')) {
+            if (interaction.customId.startsWith('host_')) {
                 return new HostHandler(this.client, interaction.customId, interaction);
             }
 
@@ -189,7 +216,7 @@ export default class InteractionHandler extends EventEmitter {
         if (interaction.isUserSelectMenu() && interaction.inCachedGuild()) {
             if (interaction.customId.startsWith('leaderboard_')) {
                 return new LeaderboardHandler(this.client, interaction.customId, interaction);
-            } else if (interaction.customId.startsWith('host_learner_')) {
+            } else if (interaction.customId.startsWith('host_')) {
                 return new HostHandler(this.client, interaction.customId, interaction);
             }
         }

--- a/src/modules/LeaderboardHandler.ts
+++ b/src/modules/LeaderboardHandler.ts
@@ -1,4 +1,4 @@
-import { ActionRowBuilder, ButtonBuilder, ButtonInteraction, ButtonStyle, ContainerBuilder, ContainerComponent, Interaction, MediaGalleryBuilder, MediaGalleryComponent, MessageFlags, ModalBuilder, ModalSubmitInteraction, SectionBuilder, SeparatorSpacingSize, TextChannel, TextDisplayBuilder, TextDisplayComponent, TextInputBuilder, TextInputStyle, User, UserSelectMenuInteraction } from 'discord.js';
+import { ActionRowBuilder, ButtonBuilder, ButtonInteraction, ButtonStyle, ContainerBuilder, ContainerComponent, EmbedBuilder, Interaction, MediaGalleryBuilder, MediaGalleryComponent, MessageFlags, ModalBuilder, ModalSubmitInteraction, SectionBuilder, SeparatorSpacingSize, TextChannel, TextDisplayBuilder, TextDisplayComponent, TextInputBuilder, TextInputStyle, User, UserSelectMenuInteraction } from 'discord.js';
 import Bot from '../Bot';
 import { EnrageLeaderboard } from '../entity/EnrageLeaderboard';
 import { LessThanOrEqual } from 'typeorm';
@@ -20,6 +20,163 @@ export default class LeaderboardHandler {
             case 'leaderboard_submit': this.handleLeaderboardSubmit(interaction as ModalSubmitInteraction); break;
         }
     }
+
+    //#region Static
+
+    public static async postLeaderBoard(client: Bot, type: number, channel: TextChannel, timespan: string | null) {
+        let dateFrom: Date;
+        let dateTo: Date;
+        let timestamp: Date = new Date();
+        let description: String;
+
+        if (timespan == null){
+            timespan = 'currentMonth';
+        }
+
+        switch(timespan){
+            case 'currentMonth':{
+                dateFrom = new Date(timestamp.getFullYear(), timestamp.getMonth(), 1, 0, 0, 0);
+                dateTo = new Date(timestamp.getFullYear(), timestamp.getMonth(), timestamp.getDate(), 23, 59, 59);
+                description = 'Current Month';
+                break;
+            }
+            case 'lastMonth':{
+                timestamp.setDate(0);
+                dateFrom = new Date(timestamp.getFullYear(), timestamp.getMonth(), 1, 0, 0, 0);
+                dateTo = new Date(timestamp.getFullYear(), timestamp.getMonth(), timestamp.getDate(), 23, 59, 59);
+                description = 'Last Month';
+                break;
+            }
+            case 'lastThreeMonths':{
+                dateTo = new Date(timestamp.getFullYear(), timestamp.getMonth(), timestamp.getDate(), 23, 59, 59);
+                timestamp.setMonth(timestamp.getMonth() - 3);
+                dateFrom = new Date(timestamp.getFullYear(), timestamp.getMonth(), timestamp.getDate(), 0, 0, 0);
+                description = 'Last 3 Months';
+                break;
+            }
+            case 'currentYear':{
+                dateFrom = new Date(timestamp.getFullYear(), 1, 1, 0, 0, 0);
+                dateTo = new Date(timestamp.getFullYear(), 12, 31, 23, 59, 59);
+                description = 'Current Year';
+                break;
+            }
+            case 'lastYear':{
+                dateFrom = new Date(timestamp.getFullYear() - 1, 1, 1, 0, 0, 0);
+                dateTo = new Date(timestamp.getFullYear() - 1, 12, 31, 23, 59, 59);
+                description = 'Last Year';
+                break;
+            }
+            default:{
+                dateFrom = new Date(2000, 1, 1, 0, 0, 0);
+                dateTo = new Date(2099, 31, 12, 23, 59, 59);
+                description = 'All Time';
+                break;
+            }
+        }
+
+        const query = `select
+                        user,
+                        sum(case when host = 1 then 1 else 0 end) as amount_hosted,
+                        sum(case when participate = 1 then 1 else 0 end) as amount_participated
+                        from host_participation
+                        where type = @type
+                        and created_at between '@dateFrom' and '@dateTo'
+                        group by user
+                        order by amount_hosted desc, amount_participated desc, user asc`
+                        .replace('@dateFrom', this.formatDate(dateFrom))
+                        .replace('@dateTo', this.formatDate(dateTo))
+                        .replace('@type', type.toString());
+
+        const result: { user: string, amount_hosted: number, amount_participated: number}[] = await client.dataSource.query(query);
+
+        const hosts = result.filter(r => r.amount_hosted > 0);
+        const participants = result.filter(r => r.amount_participated > 0).sort((a, b) => b.amount_participated - a.amount_participated);
+
+        const hostTypeLabel = type === 0 ? 'Learner Hour' : type === 1 ? 'Lore Book Kill' : type === 2 ? 'Trial' : 'Undefined';
+
+        const embed = new EmbedBuilder()
+            .setTimestamp()
+            .setTitle(`${hostTypeLabel} Leaderboard (${description})`)
+            .setColor(client.color)
+            .addFields(this.buildEmbedFields(client, hosts, participants));
+
+        await channel.send({ embeds: [embed] });
+    }
+
+    private static formatDate(date: Date): string {
+        const yyyy = date.getFullYear();
+        const mm = String(date.getMonth() + 1).padStart(2, "0");
+        const dd = String(date.getDate()).padStart(2, "0");
+        const hh = String(date.getHours()).padStart(2, "0");
+        const min = String(date.getMinutes()).padStart(2, "0");
+
+        return `${yyyy}-${mm}-${dd} ${hh}:${min}`;
+    }
+
+    private static chunkArray<T>(arr: T[], size: number): T[][] {
+        const chunks: T[][] = [];
+        for (let i = 0; i < arr.length; i += size) {
+            chunks.push(arr.slice(i, i + size));
+        }
+        return chunks;
+    }
+
+    private static buildEmbedFields(client: Bot, hosts: { user: string, amount_hosted: number, amount_participated: number}[], participants: { user: string, amount_hosted: number, amount_participated: number}[]) {
+        const { gem1, gem2, gem3 } = client.util.emojis;
+        const chunkSize = 10;
+        const hostChunks = this.chunkArray(hosts, chunkSize);
+        const participantChunks = this.chunkArray(participants, chunkSize);
+
+        const maxChunks = Math.max(hostChunks.length, participantChunks.length);
+        const fields: any[] = [];
+
+        for (let i = 0; i < maxChunks; i++) {
+            const hostSlice = hostChunks[i] ?? [];
+            const participantSlice = participantChunks[i] ?? [];
+
+            const hostText = hostSlice
+                .map((x, idx) => {
+                    const pos = i * chunkSize + idx + 1;
+                    const label = pos === 1 ? gem1 : pos === 2 ? gem2 : pos === 3 ? gem3 : `${pos}.`;
+                    return `${label} <@${x.user}> — ${x.amount_hosted}`;
+                }).join("\n");
+
+            const participantText = participantSlice
+                .map((x, idx) => {
+                    const pos = i * chunkSize + idx + 1;
+                    const label = pos === 1 ? gem1 : pos === 2 ? gem2 : pos === 3 ? gem3 : `${pos}.`;
+                    return `${label} <@${x.user}> — ${x.amount_participated}`;
+                }).join("\n");
+
+            fields.push(
+                {
+                    name: `Hosts`,// ${i * chunkSize + 1}-${i * chunkSize + hostSlice.length}`,
+                    value: hostText || "*No more hosts*",
+                    inline: true
+                },
+                {
+                    name: `Participants`,// ${i * chunkSize + 1}-${i * chunkSize + participantSlice.length}`,
+                    value: participantText || "*No more participants*",
+                    inline: true
+                }
+            );
+
+            // Add empty spacer row between blocks — except after final block
+            if (i < maxChunks - 1) {
+                fields.push({
+                    name: "\u200B",
+                    value: "\u200B",
+                    inline: false
+                });
+            }
+        }
+
+        return fields;
+    }
+
+    //#endregion
+
+    // following is deprecated
 
     //#region Moderation
 

--- a/src/modules/TicketHandler.ts
+++ b/src/modules/TicketHandler.ts
@@ -1,4 +1,4 @@
-import { ActionRowBuilder, AttachmentBuilder, ButtonBuilder, ButtonInteraction, ButtonStyle, ChannelType, ChatInputCommandInteraction, EmbedBuilder, Interaction, MessageFlags, ModalBuilder, ModalSubmitInteraction, OverwriteType, PermissionFlagsBits, SeparatorSpacingSize, TextChannel, TextInputBuilder, TextInputStyle, ThreadAutoArchiveDuration, User } from 'discord.js';
+import { ActionRowBuilder, AttachmentBuilder, ButtonBuilder, ButtonInteraction, ButtonStyle, ChannelType, ChatInputCommandInteraction, EmbedBuilder, Interaction, MessageFlags, ModalBuilder, ModalSubmitInteraction, OverwriteType, PermissionFlagsBits, SeparatorSpacingSize, StringSelectMenuBuilder, StringSelectMenuOptionBuilder, TextChannel, TextInputBuilder, TextInputStyle, ThreadAutoArchiveDuration, User } from 'discord.js';
 import Bot from '../Bot';
 import axios from 'axios';
 import TranscriptGenerator from './TranscriptGenerator';
@@ -197,38 +197,70 @@ export default class TicketHandler {
             .setCustomId(`ticket:create_learner_${interaction.user.id}`)
             .setTitle('Learner Request');
 
+        // RSN
         const rsnInput = new TextInputBuilder()
             .setCustomId('rsn')
-            .setLabel('Your RSN (RuneScape Name)')
             .setStyle(TextInputStyle.Short)
             .setRequired(true)
             .setMaxLength(12);
 
+        modal.addLabelComponents(label => label
+            .setLabel('Your RSN (RuneScape Name)')
+            .setTextInputComponent(rsnInput)
+        );
+
+        // Timezone
         const timezoneInput = new TextInputBuilder()
             .setCustomId('timezone')
-            .setLabel('Timezone and Game Times Active')
             .setStyle(TextInputStyle.Short)
             .setRequired(true);
 
+        modal.addLabelComponents(label => label
+            .setLabel('Timezone and Game Times Active')
+            .setTextInputComponent(timezoneInput)
+        );
+
+        // Confirm
         const confirmInput = new TextInputBuilder()
             .setCustomId('confirm')
-            .setLabel('Confirm you\'ve read & understand requirements')
             .setStyle(TextInputStyle.Short)
             .setRequired(true);
 
+        modal.addLabelComponents(label => label
+            .setLabel('Confirm you\'ve read & understand requirements')
+            .setTextInputComponent(confirmInput)
+        );
+
+        // Goals
         const assistanceInput = new TextInputBuilder()
             .setCustomId('goals')
-            .setLabel('What are you hoping to get out of this ticket')
             .setStyle(TextInputStyle.Paragraph)
             .setRequired(true)
             .setMaxLength(1000);
 
-        const firstRow = new ActionRowBuilder<TextInputBuilder>().addComponents(rsnInput);
-        const secondRow = new ActionRowBuilder<TextInputBuilder>().addComponents(timezoneInput);
-        const thirdRow = new ActionRowBuilder<TextInputBuilder>().addComponents(confirmInput);
-        const fourthRow = new ActionRowBuilder<TextInputBuilder>().addComponents(assistanceInput);
+        modal.addLabelComponents(label => label
+            .setLabel('What are you hoping to get out of this ticket')
+            .setTextInputComponent(assistanceInput)
+        );
 
-        modal.addComponents(firstRow, secondRow, thirdRow, fourthRow);
+        // Mode
+        const modeSelect = new StringSelectMenuBuilder()
+            .setCustomId('mode')
+            .addOptions([
+                new StringSelectMenuOptionBuilder().setLabel('Normal Mode').setValue('nm'),
+                new StringSelectMenuOptionBuilder().setLabel('100% Enrage').setValue('100'),
+                new StringSelectMenuOptionBuilder().setLabel('500% Enrage').setValue('500'),
+                new StringSelectMenuOptionBuilder().setLabel('750% Enrage').setValue('750'),
+                new StringSelectMenuOptionBuilder().setLabel('1000% Enrage').setValue('1000'),
+                new StringSelectMenuOptionBuilder().setLabel('2000% Enrage').setValue('2000'),
+                new StringSelectMenuOptionBuilder().setLabel('4000% Enrage').setValue('4000'),
+            ]);
+
+        modal.addLabelComponents(label => label
+            .setLabel('Mode & Enrage')
+            .setStringSelectMenuComponent(modeSelect)
+        );
+
         await interaction.showModal(modal);
     }
 
@@ -457,6 +489,7 @@ export default class TicketHandler {
                     formData.timezone = interaction.fields.getTextInputValue('timezone');
                     formData.confirm = interaction.fields.getTextInputValue('confirm');
                     formData.goals = interaction.fields.getTextInputValue('goals');
+                    formData.mode = interaction.fields.getStringSelectValues('mode');
                     break;
                 case 'librarian':
                     formData.timezone = interaction.fields.getTextInputValue('timezone');
@@ -489,7 +522,8 @@ export default class TicketHandler {
                 interaction.guild,
                 ticketType,
                 interaction.user.id,
-                ticketNumber
+                ticketNumber,
+                ticketType === 'learner' ? formData.mode : null
             );
 
             if (!ticketChannel) {
@@ -1411,9 +1445,14 @@ export default class TicketHandler {
         }
     }
 
-    public async createTicketChannel(guild: any, ticketType: string, userId: string, ticketNumber: number): Promise<TextChannel | null> {
+    public async createTicketChannel(guild: any, ticketType: string, userId: string, ticketNumber: number, mode: string | null = null): Promise<TextChannel | null> {
         try {
-            const channelName = `${ticketType}-${ticketNumber.toString().padStart(4, '0')}`;
+            let channelName = `${ticketType}-${ticketNumber.toString().padStart(4, '0')}`;
+
+            if (mode != null) {
+                channelName += `-${mode}`;
+            }
+
             const isStaffTicket = ticketType === 'librarian' || ticketType === 'support' || ticketType === 'teacher' || ticketType === 'trialteam';
             const isClearanceTicket = ticketType === 'clearance';
             const parentCategoryId = ticketType === 'learner' || ticketType === 'librariankill' ? this.client.channelIds.learnerTicketsCategory : isStaffTicket ? this.client.channelIds.staffTicketsCategory : isClearanceTicket ? this.client.channelIds.wipTicketCategory : this.client.channelIds.ticketCategory;
@@ -1625,6 +1664,7 @@ export default class TicketHandler {
                         { name: 'Timezone and Game Times Active', value: `\`\`\`${formData.timezone}\`\`\``, inline: false },
                         { name: 'Confirm you\'ve read & understand requirements', value: `\`\`\`${formData.confirm}\`\`\``, inline: false },
                         { name: 'What are you hoping to get out of this ticket?', value: `\`\`\`${formData.goals}\`\`\``, inline: false },
+                        { name: 'Mode and Enrage', value: `\`\`\`${formData.mode}\`\`\``, inline: false },
                     );
                     urls = urls.concat(formData.goals.match(urlRegex) || []);
                     break;

--- a/src/modules/TicketHandler.ts
+++ b/src/modules/TicketHandler.ts
@@ -1,4 +1,4 @@
-import { ActionRowBuilder, AttachmentBuilder, ButtonBuilder, ButtonInteraction, ButtonStyle, ChannelType, ChatInputCommandInteraction, EmbedBuilder, FileUploadBuilder, Interaction, Message, MessageFlags, ModalBuilder, ModalSubmitInteraction, OverwriteType, PermissionFlagsBits, SeparatorSpacingSize, StringSelectMenuBuilder, StringSelectMenuOptionBuilder, TextChannel, TextInputBuilder, TextInputStyle, ThreadAutoArchiveDuration, User, UserSelectMenuBuilder } from 'discord.js';
+import { ActionRowBuilder, AttachmentBuilder, ButtonBuilder, ButtonInteraction, ButtonStyle, ChannelType, ChatInputCommandInteraction, EmbedBuilder, FileUploadBuilder, GuildMember, Interaction, Message, MessageFlags, ModalBuilder, ModalSubmitInteraction, OverwriteType, PermissionFlagsBits, SeparatorSpacingSize, StringSelectMenuBuilder, StringSelectMenuOptionBuilder, TextChannel, TextInputBuilder, TextInputStyle, ThreadAutoArchiveDuration, User, UserSelectMenuBuilder } from 'discord.js';
 import Bot from '../Bot';
 import axios from 'axios';
 import TranscriptGenerator from './TranscriptGenerator';
@@ -42,8 +42,8 @@ export default class TicketHandler {
             case 'ticket:create_contentcreator': this.handleTicketContentCreator(interaction as ButtonInteraction<'cached'>); break;
             case 'ticket:create_other': this.handleTicketOther(interaction as ButtonInteraction<'cached'>); break;
             case 'ticket:create_learner': this.handleTicketLearner(interaction as ButtonInteraction<'cached'>); break;
-            case 'ticket:create_librarian': this.handleTicketLibrarian(interaction as ButtonInteraction<'cached'>); break;
-            case 'ticket:create_librariankill': this.handleTicketLibrarianKill(interaction as ButtonInteraction<'cached'>); break;
+            case 'ticket:create_lorebook': this.handleTicketLoreBook(interaction as ButtonInteraction<'cached'>); break;
+            case 'ticket:create_lorebookkill': this.handleTicketLoreBookKill(interaction as ButtonInteraction<'cached'>); break;
             case 'ticket:create_support': this.handleTicketSupport(interaction as ButtonInteraction<'cached'>); break;
             case 'ticket:create_teacher': this.handleTicketTeacher(interaction as ButtonInteraction<'cached'>); break;
             case 'ticket:create_trialteam': this.handleTicketTrialTeam(interaction as ButtonInteraction<'cached'>); break;
@@ -310,10 +310,10 @@ export default class TicketHandler {
         await interaction.showModal(modal);
     }
 
-    private async handleTicketLibrarian(interaction: ButtonInteraction<'cached'>): Promise<void> {
+    private async handleTicketLoreBook(interaction: ButtonInteraction<'cached'>): Promise<void> {
         const modal = new ModalBuilder()
-            .setCustomId(`ticket:create_librarian_${interaction.user.id}`)
-            .setTitle('Librarian Team staff application');
+            .setCustomId(`ticket:create_lorebook_${interaction.user.id}`)
+            .setTitle('Lore Book Crew staff application');
 
         // RSN
         const rsnInput = new TextInputBuilder()
@@ -353,10 +353,10 @@ export default class TicketHandler {
         await interaction.showModal(modal);
     }
 
-    private async handleTicketLibrarianKill(interaction: ButtonInteraction<'cached'>): Promise<void> {
+    private async handleTicketLoreBookKill(interaction: ButtonInteraction<'cached'>): Promise<void> {
         const modal = new ModalBuilder()
-            .setCustomId(`ticket:create_librariankill_${interaction.user.id}`)
-            .setTitle('Librarian Request');
+            .setCustomId(`ticket:create_lorebookkill_${interaction.user.id}`)
+            .setTitle('Lore Book Kill Request');
 
         // RSN
         const rsnInput = new TextInputBuilder()
@@ -571,7 +571,7 @@ export default class TicketHandler {
     private async handleTicketModalSubmit(interaction: ModalSubmitInteraction): Promise<void> {
         if (!interaction.inCachedGuild()) return;
 
-        await interaction.deferReply({ ephemeral: true });
+        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
         try {
             const customIdParts = interaction.customId.split('_');
@@ -608,13 +608,13 @@ export default class TicketHandler {
                     formData.timezone = interaction.fields.getTextInputValue('timezone');
                     formData.confirm = interaction.fields.getTextInputValue('confirm');
                     formData.goals = interaction.fields.getTextInputValue('goals');
-                    formData.mode = interaction.fields.getStringSelectValues('mode');
+                    formData.mode = interaction.fields.getStringSelectValues('mode').join('-');
                     break;
-                case 'librarian':
+                case 'lorebook':
                     formData.timezone = interaction.fields.getTextInputValue('timezone');
                     formData.reasons = interaction.fields.getTextInputValue('reasons');
                     break;
-                case 'librariankill':
+                case 'lorebookkill':
                     formData.timezone = interaction.fields.getTextInputValue('timezone');
                     break;
                 case 'support':
@@ -686,7 +686,7 @@ export default class TicketHandler {
     private async handleCreateClearanceTicket(interaction: ChatInputCommandInteraction): Promise<void> {
         if (!interaction.inCachedGuild()) return;
 
-        await interaction.deferReply({ ephemeral: true });
+        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
         try {
             const reportedUser: User = interaction.options.getUser('reporteduser', true);
@@ -875,9 +875,9 @@ export default class TicketHandler {
             if (isTeacher) return true;
         }
 
-        if (channel.name.startsWith('librariankill')) {
-            const isLibrarian = await this.client.util.hasRolePermissions(this.client, ['librarian', 'teacher'], interaction);
-            if (isLibrarian) return true;
+        if (channel.name.startsWith('lorebookkill')) {
+            const isLoreBookCrew = await this.client.util.hasRolePermissions(this.client, ['lorebook', 'teacher'], interaction);
+            if (isLoreBookCrew) return true;
         }
 
         const userPermissions = channel.permissionOverwrites.cache.get(interaction.user.id);
@@ -1363,7 +1363,7 @@ export default class TicketHandler {
         }, true);
 
         try {
-            await interaction.deferReply({ ephemeral: true });
+            await interaction.deferReply({ flags: MessageFlags.Ephemeral });
             client.logger.log({
                 message: `[Transcript] Successfully deferred reply for post ${forumPostId}`,
                 handler: 'ButtonHandler'
@@ -1436,7 +1436,7 @@ export default class TicketHandler {
 
             // Final attempt to notify the user
             if (!interaction.replied && !interaction.deferred) {
-                await interaction.reply({ content: 'An unexpected error occurred while fetching your transcript. Please report this.', ephemeral: true }).catch(() => {});
+                await interaction.reply({ content: 'An unexpected error occurred while fetching your transcript. Please report this.', flags: MessageFlags.Ephemeral }).catch(() => {});
             } else {
                 await interaction.editReply({ content: 'An unexpected error occurred while fetching your transcript. Please report this.' }).catch(() => {});
             }
@@ -1450,7 +1450,7 @@ export default class TicketHandler {
         }, true);
 
         try {
-            await interaction.deferReply({ ephemeral: true });
+            await interaction.deferReply({ flags: MessageFlags.Ephemeral });
             this.client.logger.log({
                 message: `[Transcript] Successfully deferred reply for post ${forumPostId}`,
                 handler: this.constructor.name
@@ -1532,7 +1532,7 @@ export default class TicketHandler {
 
             // Final attempt to notify the user
             if (!interaction.replied && !interaction.deferred) {
-                await interaction.reply({ content: 'An unexpected error occurred while fetching your transcript. Please report this.', ephemeral: true }).catch(() => {});
+                await interaction.reply({ content: 'An unexpected error occurred while fetching your transcript. Please report this.', flags: MessageFlags.Ephemeral }).catch(() => {});
             } else {
                 await interaction.editReply({ content: 'An unexpected error occurred while fetching your transcript. Please report this.' }).catch(() => {});
             }
@@ -1576,11 +1576,12 @@ export default class TicketHandler {
                 channelName += `-${mode}`;
             }
 
-            const isStaffTicket = ticketType === 'librarian' || ticketType === 'support' || ticketType === 'teacher' || ticketType === 'trialteam';
+            const isStaffTicket = ticketType === 'lorebook' || ticketType === 'support' || ticketType === 'teacher' || ticketType === 'trialteam';
             const isClearanceTicket = ticketType === 'clearance';
+            const isReportTicket = ticketType === 'report';
             const parentCategoryId =
                 ticketType === 'learner' ? this.client.channelIds.learnerTicketsCategory
-                : ticketType === 'librariankill' ? this.client.channelIds.librarianTicketsCategory
+                : ticketType === 'lorebookkill' ? this.client.channelIds.lorebookTicketsCategory
                 : isStaffTicket ? this.client.channelIds.staffTicketsCategory
                 : isClearanceTicket ? this.client.channelIds.wipTicketCategory
                 : this.client.channelIds.ticketCategory;
@@ -1589,7 +1590,7 @@ export default class TicketHandler {
             const adminRoleId = this.client.roleIds.admin;
             const ownerRoleId = this.client.roleIds.owner;
             const teacherRoleId = this.client.roleIds.teacher;
-            const librarianRoleId = this.client.roleIds.librarian;
+            const lorebookRoleId = this.client.roleIds.lorebook;
 
             // Create the channel with proper permissions
             const channel: TextChannel = await guild.channels.create({
@@ -1653,7 +1654,7 @@ export default class TicketHandler {
                 );
             }
 
-            if (ticketType === 'librariankill') {
+            if (ticketType === 'lorebookkill') {
                 await channel.permissionOverwrites.create(
                     teacherRoleId,
                     {
@@ -1668,7 +1669,7 @@ export default class TicketHandler {
                 );
 
                 await channel.permissionOverwrites.create(
-                    librarianRoleId,
+                    lorebookRoleId,
                     {
                         ViewChannel: true,
                         SendMessages: true,
@@ -1681,13 +1682,16 @@ export default class TicketHandler {
                 );
             }
 
-            if (isStaffTicket || ticketType === 'report') {
+            if (isStaffTicket || isReportTicket || isClearanceTicket) {
                 const adminRole = this.client.roles.admin;
                 const ownerRole = this.client.roles.owner;
 
                 const member = await guild.members.fetch(userId);
                 const thread = await channel.threads.create({
-                    name: isStaffTicket ? `Discussion - ${member.displayName}` : `Report - ${member.displayName}`,
+                    name: isStaffTicket ? `Discussion - ${member.displayName}`
+                    : isReportTicket ? `Report - ${member.displayName}`
+                    : isClearanceTicket ? `Clearance - ${member.displayName}`
+                    : `Undefined - ${member.displayName}`,
                     autoArchiveDuration: ThreadAutoArchiveDuration.OneWeek,
                     type: ChannelType.PrivateThread,
                     reason: 'Thread automatically created by TicketHandler'
@@ -1695,11 +1699,11 @@ export default class TicketHandler {
 
                 if (isStaffTicket) {
                     await thread.send(`${adminRole}, ${ownerRole}: Discuss the applicant here`);
-                } else {
+                } else if (isReportTicket) {
                     await thread.send(`${adminRole}, ${ownerRole}: Speak as the bot here`);
 
-                    if (formData.user_select) {
-                        for (const [_, user] of formData.user_select) {
+                    if (formData?.user_select) {
+                        for (const [_, user] of formData?.user_select) {
                             // check if reported users have warnings
                             const warning = await this.client.util.GetWarnings(user);
 
@@ -1711,6 +1715,19 @@ export default class TicketHandler {
                                 });
                             }
                         }
+                    }
+                } else if (isClearanceTicket) {
+                    await thread.send(`${adminRole}, ${ownerRole}: Speak as the bot here`);
+                    const member: GuildMember = await guild.members.fetch(userId);
+
+                    const warning = await this.client.util.GetWarnings(member.user);
+
+                    if (warning) {
+                        await thread.send({
+                            components: [warning],
+                            flags: MessageFlags.IsComponentsV2,
+                            allowedMentions: { "parse": [] }
+                        });
                     }
                 }
             }
@@ -1737,8 +1754,8 @@ export default class TicketHandler {
             const adminRole = this.client.roles.admin;
             const ownerRole = this.client.roles.owner;
             const teacherRole = this.client.roles.teacher;
-            const librarianRole = this.client.roles.librarian;
-            const isStaffTicket = ticketType === 'librarian' || ticketType === 'support' || ticketType === 'teacher' || ticketType === 'trialteam';
+            const lorebookRole = this.client.roles.lorebook;
+            const isStaffTicket = ticketType === 'lorebook' || ticketType === 'support' || ticketType === 'teacher' || ticketType === 'trialteam';
 
             // Create welcome message
             let welcomeMessage = `<@${userId}>, your ticket has been created. An ${isStaffTicket || ticketType === 'report' ? 'Admin' : adminRole} or ${isStaffTicket ? 'Owner' : ownerRole} will be with you shortly.`;
@@ -1747,8 +1764,8 @@ export default class TicketHandler {
                 welcomeMessage = `<@${userId}>, your ticket has been created. A ${teacherRole} will be with you shortly.`;
             }
 
-            if (ticketType === 'librariankill') {
-                welcomeMessage = `<@${userId}>, your ticket has been created. A ${librarianRole} will be with you shortly.`;
+            if (ticketType === 'lorebookkill') {
+                welcomeMessage = `<@${userId}>, your ticket has been created. A ${lorebookRole} will be with you shortly.`;
             }
 
             if (ticketType === 'clearance') {
@@ -1757,7 +1774,7 @@ export default class TicketHandler {
 
             // Create embed with form data using fields for better organization
             const embed = new EmbedBuilder()
-                .setTitle(`${ticketType === 'trialteam' ? 'Trial Team' : ticketType === 'librariankill' ? 'Librarian Kill' : capitalizeFirstLetter(ticketType)} Ticket`)
+                .setTitle(`${ticketType === 'trialteam' ? 'Trial Team' : ticketType === 'lorebookkill' ? 'Lore Book Kill' : capitalizeFirstLetter(ticketType)} Ticket`)
                 .setColor(this.client.color)
                 .setTimestamp()
                 .setAuthor({
@@ -1832,7 +1849,7 @@ export default class TicketHandler {
                     );
                     urls = urls.concat(formData.goals.match(urlRegex) || []);
                     break;
-                case 'librarian':
+                case 'lorebook':
                     embed.addFields(
                         { name: 'Your RSN', value: `\`\`\`${formData.rsn}\`\`\``, inline: false },
                         { name: 'When are you available ingame (in Game Time)?', value: `\`\`\`${formData.timezone}\`\`\``, inline: false },
@@ -1840,7 +1857,7 @@ export default class TicketHandler {
                     );
                     urls = urls.concat(formData.reasons.match(urlRegex) || []);
                     break;
-                case 'librariankill':
+                case 'lorebookkill':
                     embed.addFields(
                         { name: 'Your RSN', value: `\`\`\`${formData.rsn}\`\`\``, inline: false },
                         { name: 'When are you available ingame (in Game Time)?', value: `\`\`\`${formData.timezone}\`\`\``, inline: false },
@@ -1942,6 +1959,44 @@ export default class TicketHandler {
                             .setStyle(ButtonStyle.Secondary),
                     ]
                 ));
+                container.addActionRowComponents(new ActionRowBuilder<ButtonBuilder>().addComponents(
+                    [
+                        new ButtonBuilder()
+                            .setCustomId('host_learner_quickfinish')
+                            .setLabel('Finish an host')
+                            .setStyle(ButtonStyle.Secondary)
+                    ]
+                ));
+
+                await channel.send({
+                    components: [container],
+                    flags: MessageFlags.IsComponentsV2,
+                    allowedMentions: { 'parse': [] }
+                });
+            }
+
+            if (ticketType === 'lorebookkill') {
+                const container = this.client.cv2.getContainerBuilder(null, '## Additional information');
+                container.addTextDisplayComponents(builder => builder.setContent([
+                    '- Please change your discord nickname to your RSN if you haven\'t already',
+                    '- Before your scheduled hour, please review <#1404510914526580837> and the roles found in <#1405324280522346657>',
+                    '- Some mechanics include the distinction between red, blue and green colours, please let us know if you are colourblind to accomodate for that'
+                ].join('\n')));
+
+                container.addSeparatorComponents(separator => separator.setSpacing(SeparatorSpacingSize.Small));
+                container.addTextDisplayComponents(builder => builder.setContent('### Lore Book Crew Controls'));
+                container.addActionRowComponents(new ActionRowBuilder<ButtonBuilder>().addComponents(
+                    [
+                        new ButtonBuilder()
+                            .setCustomId('host_lorebook_post_nm')
+                            .setLabel('Host Normal Mode')
+                            .setStyle(ButtonStyle.Secondary),
+                        new ButtonBuilder()
+                            .setCustomId('host_lorebook_quickfinish')
+                            .setLabel('Finish an host')
+                            .setStyle(ButtonStyle.Secondary)
+                    ]
+                ));
 
                 await channel.send({
                     components: [container],
@@ -1997,7 +2052,7 @@ export default class TicketHandler {
                 break;
             case 'learner':
                 ticketObject.ticketType = 5;
-            case 'librarian':
+            case 'lorebook':
                 ticketObject.ticketType = 6;
             case 'support':
                 ticketObject.ticketType = 7;
@@ -2005,7 +2060,7 @@ export default class TicketHandler {
                 ticketObject.ticketType = 8;
             case 'trialteam':
                 ticketObject.ticketType = 9;
-            case 'librariankill':
+            case 'lorebookkill':
                 ticketObject.ticketType = 10;
         }
 

--- a/src/modules/TicketHandler.ts
+++ b/src/modules/TicketHandler.ts
@@ -1774,7 +1774,7 @@ export default class TicketHandler {
 
             // Create embed with form data using fields for better organization
             const embed = new EmbedBuilder()
-                .setTitle(`${ticketType === 'trialteam' ? 'Trial Team' : ticketType === 'lorebookkill' ? 'Lore Book Kill' : capitalizeFirstLetter(ticketType)} Ticket`)
+                .setTitle(`${ticketType === 'trialteam' ? 'Trial Team' : ticketType === 'lorebook' ? 'Lore Book Crew' : ticketType === 'lorebookkill' ? 'Lore Book Kill' : capitalizeFirstLetter(ticketType)} Ticket`)
                 .setColor(this.client.color)
                 .setTimestamp()
                 .setAuthor({

--- a/src/modules/TicketHandler.ts
+++ b/src/modules/TicketHandler.ts
@@ -1,4 +1,4 @@
-import { ActionRowBuilder, AttachmentBuilder, ButtonBuilder, ButtonInteraction, ButtonStyle, ChannelType, ChatInputCommandInteraction, EmbedBuilder, Interaction, MessageFlags, ModalBuilder, ModalSubmitInteraction, OverwriteType, PermissionFlagsBits, SeparatorSpacingSize, StringSelectMenuBuilder, StringSelectMenuOptionBuilder, TextChannel, TextInputBuilder, TextInputStyle, ThreadAutoArchiveDuration, User } from 'discord.js';
+import { ActionRowBuilder, AttachmentBuilder, ButtonBuilder, ButtonInteraction, ButtonStyle, ChannelType, ChatInputCommandInteraction, EmbedBuilder, FileUploadBuilder, Interaction, Message, MessageFlags, ModalBuilder, ModalSubmitInteraction, OverwriteType, PermissionFlagsBits, SeparatorSpacingSize, StringSelectMenuBuilder, StringSelectMenuOptionBuilder, TextChannel, TextInputBuilder, TextInputStyle, ThreadAutoArchiveDuration, User, UserSelectMenuBuilder } from 'discord.js';
 import Bot from '../Bot';
 import axios from 'axios';
 import TranscriptGenerator from './TranscriptGenerator';
@@ -61,32 +61,42 @@ export default class TicketHandler {
             .setCustomId(`ticket:create_suggestion_${interaction.user.id}`)
             .setTitle('Submit a Suggestion');
 
+        // RSN
         const rsnInput = new TextInputBuilder()
             .setCustomId('rsn')
-            .setLabel('Your RSN (RuneScape Name)')
             .setStyle(TextInputStyle.Short)
             .setRequired(true)
             .setMaxLength(12);
 
+        modal.addLabelComponents(label => label
+            .setLabel('Your RSN (RuneScape Name)')
+            .setTextInputComponent(rsnInput)
+        );
+
+        // Suggestion
         const suggestionInput = new TextInputBuilder()
             .setCustomId('suggestion')
-            .setLabel('Briefly describe your suggestion')
             .setStyle(TextInputStyle.Paragraph)
             .setRequired(true)
             .setMaxLength(1000);
 
+        modal.addLabelComponents(label => label
+            .setLabel('Briefly describe your suggestion')
+            .setTextInputComponent(suggestionInput)
+        );
+
+        // Reason
         const reasonInput = new TextInputBuilder()
             .setCustomId('reason')
-            .setLabel('Why do you think your suggestion would work?')
             .setStyle(TextInputStyle.Paragraph)
             .setRequired(true)
             .setMaxLength(1000);
 
-        const firstRow = new ActionRowBuilder<TextInputBuilder>().addComponents(rsnInput);
-        const secondRow = new ActionRowBuilder<TextInputBuilder>().addComponents(suggestionInput);
-        const thirdRow = new ActionRowBuilder<TextInputBuilder>().addComponents(reasonInput);
+        modal.addLabelComponents(label => label
+            .setLabel('Why do you think your suggestion would work?')
+            .setTextInputComponent(reasonInput)
+        );
 
-        modal.addComponents(firstRow, secondRow, thirdRow);
         await interaction.showModal(modal);
     }
 
@@ -95,40 +105,62 @@ export default class TicketHandler {
             .setCustomId(`ticket:create_report_${interaction.user.id}`)
             .setTitle('Submit a Report');
 
+        // RSN
         const rsnInput = new TextInputBuilder()
             .setCustomId('rsn')
-            .setLabel('Your RSN (RuneScape Name)')
             .setStyle(TextInputStyle.Short)
             .setRequired(true)
             .setMaxLength(12);
 
+        modal.addLabelComponents(label => label
+            .setLabel('Your RSN (RuneScape Name)')
+            .setTextInputComponent(rsnInput)
+        );
+
+        // Reported user
+        const userSelect = new UserSelectMenuBuilder()
+            .setCustomId('user_select')
+            .setRequired(true)
+            .setMaxValues(5);
+
+        modal.addLabelComponents(label => label
+            .setLabel('Who are you reporting?')
+            .setUserSelectMenuComponent(userSelect)
+        );
+
         const reportedUserInput = new TextInputBuilder()
             .setCustomId('reported_user')
-            .setLabel('RSN & Discord User you are reporting')
             .setStyle(TextInputStyle.Short)
             .setRequired(true)
             .setMaxLength(100);
 
+        modal.addLabelComponents(label => label
+            .setLabel('RSN of the user, you are reporting')
+            .setTextInputComponent(reportedUserInput)
+        );
+
+        // Reason
         const reasonInput = new TextInputBuilder()
             .setCustomId('reason')
-            .setLabel('What is the reason for your report?')
-            .setStyle(TextInputStyle.Short)
-            .setRequired(true)
-            .setMaxLength(200);
-
-        const descriptionInput = new TextInputBuilder()
-            .setCustomId('description')
-            .setLabel('Briefly describe the issue.')
             .setStyle(TextInputStyle.Paragraph)
             .setRequired(true)
             .setMaxLength(1000);
 
-        const firstRow = new ActionRowBuilder<TextInputBuilder>().addComponents(rsnInput);
-        const secondRow = new ActionRowBuilder<TextInputBuilder>().addComponents(reportedUserInput);
-        const thirdRow = new ActionRowBuilder<TextInputBuilder>().addComponents(reasonInput);
-        const fourthRow = new ActionRowBuilder<TextInputBuilder>().addComponents(descriptionInput);
+        modal.addLabelComponents(label => label
+            .setLabel('What is the reason for your report?')
+            .setTextInputComponent(reasonInput)
+        );
 
-        modal.addComponents(firstRow, secondRow, thirdRow, fourthRow);
+        // Evidence
+        const fileUpload = new FileUploadBuilder()
+            .setCustomId('attachment')
+            .setRequired(false);
+
+        modal.addLabelComponents(label => label
+            .setLabel('Please provide any evidence you got')
+            .setFileUploadComponent(fileUpload)
+        );
+
         await interaction.showModal(modal);
     }
 
@@ -137,32 +169,40 @@ export default class TicketHandler {
             .setCustomId(`ticket:create_contentcreator_${interaction.user.id}`)
             .setTitle('Content Creator Application');
 
+        // RSN
         const rsnInput = new TextInputBuilder()
             .setCustomId('rsn')
-            .setLabel('Your RSN (RuneScape Name)')
             .setStyle(TextInputStyle.Short)
             .setRequired(true)
             .setMaxLength(12);
 
+        modal.addLabelComponents(label => label
+            .setLabel('Your RSN (RuneScape Name)')
+            .setTextInputComponent(rsnInput)
+        );
+
         const platformInput = new TextInputBuilder()
             .setCustomId('platform_url')
-            .setLabel("What's your streaming platform URL?")
             .setStyle(TextInputStyle.Short)
             .setRequired(true)
             .setMaxLength(200);
 
+        modal.addLabelComponents(label => label
+            .setLabel('What\'s your streaming platform URL?')
+            .setTextInputComponent(platformInput)
+        );
+
         const additionalInput = new TextInputBuilder()
             .setCustomId('additional')
-            .setLabel("Anything else you'd like to add?")
             .setStyle(TextInputStyle.Paragraph)
             .setRequired(true)
             .setMaxLength(1000);
 
-        const firstRow = new ActionRowBuilder<TextInputBuilder>().addComponents(rsnInput);
-        const secondRow = new ActionRowBuilder<TextInputBuilder>().addComponents(platformInput);
-        const thirdRow = new ActionRowBuilder<TextInputBuilder>().addComponents(additionalInput);
+        modal.addLabelComponents(label => label
+            .setLabel('Anything else you\'d like to add?')
+            .setTextInputComponent(additionalInput)
+        );
 
-        modal.addComponents(firstRow, secondRow, thirdRow);
         await interaction.showModal(modal);
     }
 
@@ -171,24 +211,29 @@ export default class TicketHandler {
             .setCustomId(`ticket:create_other_${interaction.user.id}`)
             .setTitle('Other Support Request');
 
+        // RSN
         const rsnInput = new TextInputBuilder()
             .setCustomId('rsn')
-            .setLabel('Your RSN (RuneScape Name)')
             .setStyle(TextInputStyle.Short)
             .setRequired(true)
             .setMaxLength(12);
 
+        modal.addLabelComponents(label => label
+            .setLabel('Your RSN (RuneScape Name)')
+            .setTextInputComponent(rsnInput)
+        );
+
         const assistanceInput = new TextInputBuilder()
             .setCustomId('assistance')
-            .setLabel('How can we assist you?')
             .setStyle(TextInputStyle.Paragraph)
             .setRequired(true)
             .setMaxLength(1000);
 
-        const firstRow = new ActionRowBuilder<TextInputBuilder>().addComponents(rsnInput);
-        const secondRow = new ActionRowBuilder<TextInputBuilder>().addComponents(assistanceInput);
+        modal.addLabelComponents(label => label
+            .setLabel('How can we assist you?')
+            .setTextInputComponent(assistanceInput)
+        );
 
-        modal.addComponents(firstRow, secondRow);
         await interaction.showModal(modal);
     }
 
@@ -216,7 +261,7 @@ export default class TicketHandler {
             .setRequired(true);
 
         modal.addLabelComponents(label => label
-            .setLabel('Timezone and Game Times Active')
+            .setLabel('When are you available ingame (in Game Time)?')
             .setTextInputComponent(timezoneInput)
         );
 
@@ -254,10 +299,11 @@ export default class TicketHandler {
                 new StringSelectMenuOptionBuilder().setLabel('1000% Enrage').setValue('1000'),
                 new StringSelectMenuOptionBuilder().setLabel('2000% Enrage').setValue('2000'),
                 new StringSelectMenuOptionBuilder().setLabel('4000% Enrage').setValue('4000'),
-            ]);
+            ])
+            .setMaxValues(7);
 
         modal.addLabelComponents(label => label
-            .setLabel('Mode & Enrage')
+            .setLabel('What do you want to learn? (Select any)')
             .setStringSelectMenuComponent(modeSelect)
         );
 
@@ -269,32 +315,41 @@ export default class TicketHandler {
             .setCustomId(`ticket:create_librarian_${interaction.user.id}`)
             .setTitle('Librarian Team staff application');
 
+        // RSN
         const rsnInput = new TextInputBuilder()
             .setCustomId('rsn')
-            .setLabel('Your RSN (RuneScape Name)')
             .setStyle(TextInputStyle.Short)
             .setRequired(true)
             .setMaxLength(12);
 
+        modal.addLabelComponents(label => label
+            .setLabel('Your RSN (RuneScape Name)')
+            .setTextInputComponent(rsnInput)
+        );
+
+        // Timezone
         const timezoneInput = new TextInputBuilder()
             .setCustomId('timezone')
-            .setLabel('Timezone and Game Times active')
             .setStyle(TextInputStyle.Short)
             .setRequired(true);
 
+        modal.addLabelComponents(label => label
+            .setLabel('When are you available ingame (in Game Time)?')
+            .setTextInputComponent(timezoneInput)
+        );
+
+        // Reason
         const reasonsInput = new TextInputBuilder()
             .setCustomId('reasons')
-            .setLabel('Why are you applying for this role?')
             .setStyle(TextInputStyle.Paragraph)
             .setRequired(true)
             .setMaxLength(1000);
 
+        modal.addLabelComponents(label => label
+            .setLabel('Why are you applying for this role?')
+            .setTextInputComponent(reasonsInput)
+        );
 
-        const firstRow = new ActionRowBuilder<TextInputBuilder>().addComponents(rsnInput);
-        const secondRow = new ActionRowBuilder<TextInputBuilder>().addComponents(timezoneInput);
-        const thirdRow = new ActionRowBuilder<TextInputBuilder>().addComponents(reasonsInput);
-
-        modal.addComponents(firstRow, secondRow, thirdRow);
         await interaction.showModal(modal);
     }
 
@@ -303,23 +358,29 @@ export default class TicketHandler {
             .setCustomId(`ticket:create_librariankill_${interaction.user.id}`)
             .setTitle('Librarian Request');
 
+        // RSN
         const rsnInput = new TextInputBuilder()
             .setCustomId('rsn')
-            .setLabel('Your RSN (RuneScape Name)')
             .setStyle(TextInputStyle.Short)
             .setRequired(true)
             .setMaxLength(12);
 
+        modal.addLabelComponents(label => label
+            .setLabel('Your RSN (RuneScape Name)')
+            .setTextInputComponent(rsnInput)
+        );
+
+        // Timezone
         const timezoneInput = new TextInputBuilder()
             .setCustomId('timezone')
-            .setLabel('Timezone and Game Times Active')
             .setStyle(TextInputStyle.Short)
             .setRequired(true);
 
-        const firstRow = new ActionRowBuilder<TextInputBuilder>().addComponents(rsnInput);
-        const secondRow = new ActionRowBuilder<TextInputBuilder>().addComponents(timezoneInput);
+        modal.addLabelComponents(label => label
+            .setLabel('When are you available ingame (in Game Time)?')
+            .setTextInputComponent(timezoneInput)
+        );
 
-        modal.addComponents(firstRow, secondRow);
         await interaction.showModal(modal);
     }
 
@@ -328,31 +389,41 @@ export default class TicketHandler {
             .setCustomId(`ticket:create_support_${interaction.user.id}`)
             .setTitle('Support Team staff application');
 
+        // RSN
         const rsnInput = new TextInputBuilder()
             .setCustomId('rsn')
-            .setLabel('Your RSN (RuneScape Name)')
             .setStyle(TextInputStyle.Short)
             .setRequired(true)
             .setMaxLength(12);
 
+        modal.addLabelComponents(label => label
+            .setLabel('Your RSN (RuneScape Name)')
+            .setTextInputComponent(rsnInput)
+        );
+
+        // Timezone
         const timezoneInput = new TextInputBuilder()
             .setCustomId('timezone')
-            .setLabel('Timezone and Game Times active')
             .setStyle(TextInputStyle.Short)
             .setRequired(true);
 
+        modal.addLabelComponents(label => label
+            .setLabel('When are you available ingame (in Game Time)?')
+            .setTextInputComponent(timezoneInput)
+        );
+
+        // Reason
         const reasonsInput = new TextInputBuilder()
             .setCustomId('reasons')
-            .setLabel('Why are you applying for this role?')
             .setStyle(TextInputStyle.Paragraph)
             .setRequired(true)
             .setMaxLength(1000);
 
-        const firstRow = new ActionRowBuilder<TextInputBuilder>().addComponents(rsnInput);
-        const secondRow = new ActionRowBuilder<TextInputBuilder>().addComponents(timezoneInput);
-        const thirdRow = new ActionRowBuilder<TextInputBuilder>().addComponents(reasonsInput);
+        modal.addLabelComponents(label => label
+            .setLabel('Why are you applying for this role?')
+            .setTextInputComponent(reasonsInput)
+        );
 
-        modal.addComponents(firstRow, secondRow, thirdRow);
         await interaction.showModal(modal);
     }
 
@@ -361,45 +432,70 @@ export default class TicketHandler {
             .setCustomId(`ticket:create_teacher_${interaction.user.id}`)
             .setTitle('Teacher Team staff application');
 
+        // RSN
         const rsnInput = new TextInputBuilder()
             .setCustomId('rsn')
-            .setLabel('Your RSN (RuneScape Name)')
             .setStyle(TextInputStyle.Short)
             .setRequired(true)
             .setMaxLength(12);
 
+        modal.addLabelComponents(label => label
+            .setLabel('Your RSN (RuneScape Name)')
+            .setTextInputComponent(rsnInput)
+        );
+
+        // Timezone
         const timezoneInput = new TextInputBuilder()
             .setCustomId('timezone')
-            .setLabel('Timezone and Game Times active')
             .setStyle(TextInputStyle.Short)
             .setRequired(true);
 
-        const enrageInput = new TextInputBuilder()
-            .setCustomId('enrage')
-            .setLabel('Which enrage do you want to teach people')
-            .setStyle(TextInputStyle.Short)
-            .setRequired(true);
+        modal.addLabelComponents(label => label
+            .setLabel('When are you available ingame (in Game Time)?')
+            .setTextInputComponent(timezoneInput)
+        );
 
-        const presetKcInput = new TextInputBuilder()
-            .setCustomId('presetkc')
-            .setLabel('Please provide your preset and kc')
-            .setStyle(TextInputStyle.Short)
-            .setRequired(true);
-
+        // Reason
         const reasonsInput = new TextInputBuilder()
             .setCustomId('reasons')
-            .setLabel('Why are you applying for this role?')
             .setStyle(TextInputStyle.Paragraph)
             .setRequired(true)
             .setMaxLength(1000);
 
-        const firstRow = new ActionRowBuilder<TextInputBuilder>().addComponents(rsnInput);
-        const secondRow = new ActionRowBuilder<TextInputBuilder>().addComponents(timezoneInput);
-        const thirdRow = new ActionRowBuilder<TextInputBuilder>().addComponents(enrageInput);
-        const fourthRow = new ActionRowBuilder<TextInputBuilder>().addComponents(presetKcInput);
-        const fifthRow = new ActionRowBuilder<TextInputBuilder>().addComponents(reasonsInput);
+        modal.addLabelComponents(label => label
+            .setLabel('Why are you applying for this role?')
+            .setTextInputComponent(reasonsInput)
+        );
 
-        modal.addComponents(firstRow, secondRow, thirdRow, fourthRow, fifthRow);
+        // Enrage
+        const modeSelect = new StringSelectMenuBuilder()
+            .setCustomId('enrage')
+            .addOptions([
+                new StringSelectMenuOptionBuilder().setLabel('Normal Mode').setValue('nm'),
+                new StringSelectMenuOptionBuilder().setLabel('100% Enrage').setValue('100'),
+                new StringSelectMenuOptionBuilder().setLabel('500% Enrage').setValue('500'),
+                new StringSelectMenuOptionBuilder().setLabel('750% Enrage').setValue('750'),
+                new StringSelectMenuOptionBuilder().setLabel('1000% Enrage').setValue('1000'),
+                new StringSelectMenuOptionBuilder().setLabel('2000% Enrage').setValue('2000'),
+                new StringSelectMenuOptionBuilder().setLabel('4000% Enrage').setValue('4000'),
+            ])
+            .setMaxValues(7);
+
+        modal.addLabelComponents(label => label
+            .setLabel('Which enrage do you want to teach people?')
+            .setStringSelectMenuComponent(modeSelect)
+        );
+
+        // presetkc
+        const fileUpload = new FileUploadBuilder()
+            .setCustomId('attachment')
+            .setRequired(false);
+
+        modal.addLabelComponents(label => label
+            .setLabel('Please provide your preset and kc')
+            .setFileUploadComponent(fileUpload)
+        );
+
         await interaction.showModal(modal);
     }
 
@@ -408,45 +504,67 @@ export default class TicketHandler {
             .setCustomId(`ticket:create_trialteam_${interaction.user.id}`)
             .setTitle('Trial Team staff application');
 
+        // RSN
         const rsnInput = new TextInputBuilder()
             .setCustomId('rsn')
-            .setLabel('Your RSN (RuneScape Name)')
             .setStyle(TextInputStyle.Short)
             .setRequired(true)
             .setMaxLength(12);
 
+        modal.addLabelComponents(label => label
+            .setLabel('Your RSN (RuneScape Name)')
+            .setTextInputComponent(rsnInput)
+        );
+
+        // Timezone
         const timezoneInput = new TextInputBuilder()
             .setCustomId('timezone')
-            .setLabel('Timezone and Game Times active')
             .setStyle(TextInputStyle.Short)
             .setRequired(true);
 
-        const enrageInput = new TextInputBuilder()
-            .setCustomId('enrage')
-            .setLabel('Which enrage do you want to trial people')
-            .setStyle(TextInputStyle.Short)
-            .setRequired(true);
+        modal.addLabelComponents(label => label
+            .setLabel('When are you available ingame (in Game Time)?')
+            .setTextInputComponent(timezoneInput)
+        );
 
-        const presetKcInput = new TextInputBuilder()
-            .setCustomId('presetkc')
-            .setLabel('Please provide your preset and kc')
-            .setStyle(TextInputStyle.Short)
-            .setRequired(true);
-
+        // Reason
         const reasonsInput = new TextInputBuilder()
             .setCustomId('reasons')
-            .setLabel('Why are you applying for this role?')
             .setStyle(TextInputStyle.Paragraph)
             .setRequired(true)
             .setMaxLength(1000);
 
-        const firstRow = new ActionRowBuilder<TextInputBuilder>().addComponents(rsnInput);
-        const secondRow = new ActionRowBuilder<TextInputBuilder>().addComponents(timezoneInput);
-        const thirdRow = new ActionRowBuilder<TextInputBuilder>().addComponents(enrageInput);
-        const fourthRow = new ActionRowBuilder<TextInputBuilder>().addComponents(presetKcInput);
-        const fifthRow = new ActionRowBuilder<TextInputBuilder>().addComponents(reasonsInput);
+        modal.addLabelComponents(label => label
+            .setLabel('Why are you applying for this role?')
+            .setTextInputComponent(reasonsInput)
+        );
 
-        modal.addComponents(firstRow, secondRow, thirdRow, fourthRow, fifthRow);
+        // Enrage
+        const modeSelect = new StringSelectMenuBuilder()
+            .setCustomId('enrage')
+            .addOptions([
+                new StringSelectMenuOptionBuilder().setLabel('500% Enrage').setValue('500'),
+                new StringSelectMenuOptionBuilder().setLabel('750% Enrage').setValue('750'),
+                new StringSelectMenuOptionBuilder().setLabel('1000% Enrage').setValue('1000'),
+                new StringSelectMenuOptionBuilder().setLabel('2000% Enrage').setValue('2000'),
+                new StringSelectMenuOptionBuilder().setLabel('4000% Enrage').setValue('4000'),
+            ])
+            .setMaxValues(5);
+
+        modal.addLabelComponents(label => label
+            .setLabel('Which enrage do you want to trial people?')
+            .setStringSelectMenuComponent(modeSelect)
+        );
+
+        // presetkc
+        const fileUpload = new FileUploadBuilder()
+            .setCustomId('attachment')
+            .setRequired(false);
+
+        modal.addLabelComponents(label => label
+            .setLabel('Please provide your preset and kc')
+            .setFileUploadComponent(fileUpload)
+        );
         await interaction.showModal(modal);
     }
 
@@ -470,9 +588,10 @@ export default class TicketHandler {
 
             switch (ticketType) {
                 case 'report':
+                    formData.user_select = interaction.fields.getSelectedUsers('user_select');
                     formData.reported_user = interaction.fields.getTextInputValue('reported_user');
                     formData.reason = interaction.fields.getTextInputValue('reason');
-                    formData.description = interaction.fields.getTextInputValue('description');
+                    formData.attachment = interaction.fields.getUploadedFiles('attachment');
                     break;
                 case 'suggestion':
                     formData.suggestion = interaction.fields.getTextInputValue('suggestion');
@@ -505,14 +624,14 @@ export default class TicketHandler {
                 case 'teacher':
                     formData.timezone = interaction.fields.getTextInputValue('timezone');
                     formData.reasons = interaction.fields.getTextInputValue('reasons');
-                    formData.presetkc = interaction.fields.getTextInputValue('presetkc');
-                    formData.enrage = interaction.fields.getTextInputValue('enrage');
+                    formData.attachment = interaction.fields.getUploadedFiles('attachment');
+                    formData.enrage = interaction.fields.getStringSelectValues('enrage');
                     break;
                 case 'trialteam':
                     formData.timezone = interaction.fields.getTextInputValue('timezone');
                     formData.reasons = interaction.fields.getTextInputValue('reasons');
-                    formData.presetkc = interaction.fields.getTextInputValue('presetkc');
-                    formData.enrage = interaction.fields.getTextInputValue('enrage');
+                    formData.attachment = interaction.fields.getUploadedFiles('attachment');
+                    formData.enrage = interaction.fields.getStringSelectValues('enrage');
                     break;
             }
 
@@ -523,7 +642,8 @@ export default class TicketHandler {
                 ticketType,
                 interaction.user.id,
                 ticketNumber,
-                ticketType === 'learner' ? formData.mode : null
+                ticketType === 'learner' ? formData.mode : null,
+                formData
             );
 
             if (!ticketChannel) {
@@ -584,7 +704,8 @@ export default class TicketHandler {
                 interaction.guild,
                 'clearance',
                 reportedUser.id,
-                ticketNumber
+                ticketNumber,
+                null
             );
 
             if (!ticketChannel) {
@@ -755,7 +876,7 @@ export default class TicketHandler {
         }
 
         if (channel.name.startsWith('librariankill')) {
-            const isLibrarian = await this.client.util.hasRolePermissions(this.client, ['librarian'], interaction);
+            const isLibrarian = await this.client.util.hasRolePermissions(this.client, ['librarian', 'teacher'], interaction);
             if (isLibrarian) return true;
         }
 
@@ -771,7 +892,7 @@ export default class TicketHandler {
         const messages = await UtilityHandler.readAllMessages(channel);
         const messageArray = Array.from(messages.values());
 
-        const transcriptBuffer = await TranscriptGenerator.createTranscript(messages, channel.name);
+        const transcriptBuffer = await TranscriptGenerator.createTranscript(messages, channel.name, this.client);
         const transcriptAttachment = new AttachmentBuilder(transcriptBuffer, { name: `${channel.name}-transcript.html` });
 
         const welcomeMessage = messages.find(msg =>
@@ -813,16 +934,16 @@ export default class TicketHandler {
 
         if (ticketType === 'report' && originalTicketEmbed?.fields) {
             const reportedUserField = originalTicketEmbed.fields.find(field =>
-                field.name === 'Reported User'
+                field.name === 'Reported Users'
             );
 
             if (reportedUserField) {
-                const reportedUser = reportedUserField.value.replace(/```/g, '').trim();
+                const reportedUser = reportedUserField.value.replace(/```/g, '').replace(/(<@\d+>)/g, '').trim();
                 forumTitle = `Report-${ticketOpener}-${reportedUser}`;
             }
         } else if (ticketType === 'clearance' && originalTicketEmbed?.fields) {
             const reportedUserField = originalTicketEmbed.fields.find(field =>
-                field.name === 'RSN' || 'Reported User'
+                field.name === 'RSN' || 'Reported Users'
             );
 
             if (reportedUserField) {
@@ -876,7 +997,8 @@ export default class TicketHandler {
 
             for (const message of messageArray) {
                 if (message.author.id === this.client.user?.id) {
-                    continue;
+                    //continue;
+                    //we want that now.
                 }
 
                 const messageDate = message.createdAt.toLocaleDateString();
@@ -918,7 +1040,8 @@ export default class TicketHandler {
 
                 if (hasAttachments) {
                     for (const attachment of message.attachments.values()) {
-                        const attachmentBlock = `**[${timeOnly}] ${author}:** ${attachment.url}\n`;
+                        const newUrl: string = await this.client.util.reuploadImage(attachment.url);
+                        const attachmentBlock = `**[${timeOnly}] ${author}:** ${newUrl}\n`;
 
                         if (currentBlock.length + attachmentBlock.length > maxLength) {
                             // BANDAID
@@ -1235,7 +1358,7 @@ export default class TicketHandler {
 
     public static async handleDMTranscriptDownload(client: Bot, interaction: ButtonInteraction, forumPostId: string): Promise<void> {
         client.logger.log({
-            message: `[Transcript] handleDMTranscriptDownload called with forumPostId: "${forumPostId}", user: ${interaction.user.id}`,
+            message: `[Transcript] handleDMTranscriptDownload called with forumPostId: "${forumPostId}", user: ${interaction.user.id} / ${interaction.user.displayName}`,
             handler: 'ButtonHandler'
         }, true);
 
@@ -1322,7 +1445,7 @@ export default class TicketHandler {
 
     private async handleTranscriptDownload(interaction: ButtonInteraction, forumPostId: string): Promise<void> {
         this.client.logger.log({
-            message: `[Transcript] handleTranscriptDownload called with forumPostId: "${forumPostId}", user: ${interaction.user.id}`,
+            message: `[Transcript] handleTranscriptDownload called with forumPostId: "${forumPostId}", user: ${interaction.user.id} / ${interaction.user.displayName}`,
             handler: this.constructor.name
         }, true);
 
@@ -1445,7 +1568,7 @@ export default class TicketHandler {
         }
     }
 
-    public async createTicketChannel(guild: any, ticketType: string, userId: string, ticketNumber: number, mode: string | null = null): Promise<TextChannel | null> {
+    public async createTicketChannel(guild: any, ticketType: string, userId: string, ticketNumber: number, mode: string | null = null, formData: any | null = null): Promise<TextChannel | null> {
         try {
             let channelName = `${ticketType}-${ticketNumber.toString().padStart(4, '0')}`;
 
@@ -1532,6 +1655,19 @@ export default class TicketHandler {
 
             if (ticketType === 'librariankill') {
                 await channel.permissionOverwrites.create(
+                    teacherRoleId,
+                    {
+                        ViewChannel: true,
+                        SendMessages: true,
+                        ReadMessageHistory: true,
+                        AttachFiles: true,
+                        EmbedLinks: true,
+                        ManageMessages: true,
+                        ManageChannels: true,
+                    }
+                );
+
+                await channel.permissionOverwrites.create(
                     librarianRoleId,
                     {
                         ViewChannel: true,
@@ -1545,19 +1681,38 @@ export default class TicketHandler {
                 );
             }
 
-            if (isStaffTicket) {
+            if (isStaffTicket || ticketType === 'report') {
                 const adminRole = this.client.roles.admin;
                 const ownerRole = this.client.roles.owner;
 
                 const member = await guild.members.fetch(userId);
                 const thread = await channel.threads.create({
-                    name: `Discussion - ${member.displayName}`,
+                    name: isStaffTicket ? `Discussion - ${member.displayName}` : `Report - ${member.displayName}`,
                     autoArchiveDuration: ThreadAutoArchiveDuration.OneWeek,
                     type: ChannelType.PrivateThread,
                     reason: 'Thread automatically created by TicketHandler'
                 });
 
-                await thread.send(`${adminRole}, ${ownerRole}: Discuss the applicant here`);
+                if (isStaffTicket) {
+                    await thread.send(`${adminRole}, ${ownerRole}: Discuss the applicant here`);
+                } else {
+                    await thread.send(`${adminRole}, ${ownerRole}: Speak as the bot here`);
+
+                    if (formData.user_select) {
+                        for (const [_, user] of formData.user_select) {
+                            // check if reported users have warnings
+                            const warning = await this.client.util.GetWarnings(user);
+
+                            if (warning) {
+                                await thread.send({
+                                    components: [warning],
+                                    flags: MessageFlags.IsComponentsV2,
+                                    allowedMentions: { "parse": [] }
+                                });
+                            }
+                        }
+                    }
+                }
             }
 
             this.client.logger.log({
@@ -1586,7 +1741,7 @@ export default class TicketHandler {
             const isStaffTicket = ticketType === 'librarian' || ticketType === 'support' || ticketType === 'teacher' || ticketType === 'trialteam';
 
             // Create welcome message
-            let welcomeMessage = `<@${userId}>, your ticket has been created. An ${isStaffTicket ? 'Admin' : adminRole} or ${isStaffTicket ? 'Owner' : ownerRole} will be with you shortly.`;
+            let welcomeMessage = `<@${userId}>, your ticket has been created. An ${isStaffTicket || ticketType === 'report' ? 'Admin' : adminRole} or ${isStaffTicket ? 'Owner' : ownerRole} will be with you shortly.`;
 
             if (ticketType === 'learner') {
                 welcomeMessage = `<@${userId}>, your ticket has been created. A ${teacherRole} will be with you shortly.`;
@@ -1626,15 +1781,19 @@ export default class TicketHandler {
                     urls = urls.concat(formData.reason.match(urlRegex) || []);
                     break;
                 case 'report':
+                    let reportedUsers: string = '';
+                    if (formData.user_select) {
+                        for (const [_, user] of formData.user_select) {
+                            reportedUsers += `<@${user.id}>\n`;
+                        }
+                    }
+
                     embed.addFields(
                         { name: 'Your RSN', value: `\`\`\`${formData.rsn}\`\`\``, inline: false },
-                        { name: 'Reported User', value: `\`\`\`${formData.reported_user}\`\`\``, inline: false },
+                        { name: 'Reported Users', value: `${reportedUsers.trim()}\n\`\`\`${formData.reported_user}\`\`\``, inline: false },
                         { name: 'Reason', value: `\`\`\`${formData.reason}\`\`\``, inline: false },
-                        { name: 'Description', value: `\`\`\`${formData.description}\`\`\``, inline: false }
                     );
-
                     urls = urls.concat(formData.reason.match(urlRegex) || []);
-                    urls = urls.concat(formData.description.match(urlRegex) || []);
                     break;
                 case 'contentcreator':
                     embed.addFields(
@@ -1666,7 +1825,7 @@ export default class TicketHandler {
                 case 'learner':
                     embed.addFields(
                         { name: 'Your RSN', value: `\`\`\`${formData.rsn}\`\`\``, inline: false },
-                        { name: 'Timezone and Game Times Active', value: `\`\`\`${formData.timezone}\`\`\``, inline: false },
+                        { name: 'When are you available ingame (in Game Time)?', value: `\`\`\`${formData.timezone}\`\`\``, inline: false },
                         { name: 'Confirm you\'ve read & understand requirements', value: `\`\`\`${formData.confirm}\`\`\``, inline: false },
                         { name: 'What are you hoping to get out of this ticket?', value: `\`\`\`${formData.goals}\`\`\``, inline: false },
                         { name: 'Mode and Enrage', value: `\`\`\`${formData.mode}\`\`\``, inline: false },
@@ -1676,7 +1835,7 @@ export default class TicketHandler {
                 case 'librarian':
                     embed.addFields(
                         { name: 'Your RSN', value: `\`\`\`${formData.rsn}\`\`\``, inline: false },
-                        { name: 'Timezone and Game Times active', value: `\`\`\`${formData.timezone}\`\`\``, inline: false },
+                        { name: 'When are you available ingame (in Game Time)?', value: `\`\`\`${formData.timezone}\`\`\``, inline: false },
                         { name: 'Why are you applying for this role?', value: `\`\`\`${formData.reasons}\`\`\``, inline: false }
                     );
                     urls = urls.concat(formData.reasons.match(urlRegex) || []);
@@ -1684,13 +1843,13 @@ export default class TicketHandler {
                 case 'librariankill':
                     embed.addFields(
                         { name: 'Your RSN', value: `\`\`\`${formData.rsn}\`\`\``, inline: false },
-                        { name: 'Timezone and Game Times Active', value: `\`\`\`${formData.timezone}\`\`\``, inline: false },
+                        { name: 'When are you available ingame (in Game Time)?', value: `\`\`\`${formData.timezone}\`\`\``, inline: false },
                     );
                     break;
                 case 'support':
                     embed.addFields(
                         { name: 'Your RSN', value: `\`\`\`${formData.rsn}\`\`\``, inline: false },
-                        { name: 'Timezone and Game Times active', value: `\`\`\`${formData.timezone}\`\`\``, inline: false },
+                        { name: 'When are you available ingame (in Game Time)?', value: `\`\`\`${formData.timezone}\`\`\``, inline: false },
                         { name: 'Why are you applying for this role?', value: `\`\`\`${formData.reasons}\`\`\``, inline: false }
                     );
                     urls = urls.concat(formData.reasons.match(urlRegex) || []);
@@ -1698,25 +1857,29 @@ export default class TicketHandler {
                 case 'teacher':
                     embed.addFields(
                         { name: 'Your RSN', value: `\`\`\`${formData.rsn}\`\`\``, inline: false },
-                        { name: 'Timezone and Game Times active', value: `\`\`\`${formData.timezone}\`\`\``, inline: false },
+                        { name: 'When are you available ingame (in Game Time)?', value: `\`\`\`${formData.timezone}\`\`\``, inline: false },
                         { name: 'Which enrage do you want to teach people', value: `\`\`\`${formData.enrage}\`\`\``, inline: false },
-                        { name: 'Please provide your preset and kc', value: `\`\`\`${formData.presetkc}\`\`\``, inline: false },
                         { name: 'Why are you applying for this role?', value: `\`\`\`${formData.reasons}\`\`\``, inline: false }
                     );
-                    urls = urls.concat(formData.presetkc.match(urlRegex) || []);
+
                     urls = urls.concat(formData.reasons.match(urlRegex) || []);
                     break;
                 case 'trialteam':
                     embed.addFields(
                         { name: 'Your RSN', value: `\`\`\`${formData.rsn}\`\`\``, inline: false },
-                        { name: 'Timezone and Game Times active', value: `\`\`\`${formData.timezone}\`\`\``, inline: false },
+                        { name: 'When are you available ingame (in Game Time)?', value: `\`\`\`${formData.timezone}\`\`\``, inline: false },
                         { name: 'Which enrage do you want to trial people', value: `\`\`\`${formData.enrage}\`\`\``, inline: false },
-                        { name: 'Please provide your preset and kc', value: `\`\`\`${formData.presetkc}\`\`\``, inline: false },
                         { name: 'Why are you applying for this role?', value: `\`\`\`${formData.reasons}\`\`\``, inline: false }
                     );
-                    urls = urls.concat(formData.presetkc.match(urlRegex) || []);
+
                     urls = urls.concat(formData.reasons.match(urlRegex) || []);
                     break;
+            }
+
+            if (formData.attachment) {
+                for (const [_, image] of formData.attachment) {
+                    urls.push(image.url);
+                }
             }
 
             // Create close button
@@ -1740,7 +1903,9 @@ export default class TicketHandler {
                     '- Your overall PvM experience',
                     '- A screenshot of your Amascut preset to provide feedback',
                     '- A screenshot of your kill count and current PR (please include your RSN in screenshot)',
-                    '- Please change your discord nickname to your RSN if you haven\'t already'
+                    '- Please change your discord nickname to your RSN if you haven\'t already',
+                    '- Before your scheduled hour, please review <#1404510914526580837> and the roles found in <#1405324280522346657>',
+                    '- Some mechanics include the distinction between red, blue and green colours, please let us know if you are colourblind to accomodate for that'
                 ].join('\n')));
 
                 container.addSeparatorComponents(separator => separator.setSpacing(SeparatorSpacingSize.Small));
@@ -1786,7 +1951,7 @@ export default class TicketHandler {
             }
 
             if (urls.length > 0) {
-                await channel.send(`Found following URL's:\n${urls.join('\n\n')}`);
+                await channel.send(`Found following URL's / attachments:\n${urls.join('\n\n')}`);
             }
 
             this.client.logger.log({
@@ -1881,6 +2046,44 @@ export default class TicketHandler {
         }
 
         await warningRepository.save(existingEntries);
+    }
+
+    //#endregion
+
+    //#region MessageSync
+
+    public static async SyncMessage(client: Bot, message: Message<true>) {
+        if ((message.channel.parentId === client.channelIds.ticketCategory || message.channel.parentId === client.channelIds.wipTicketCategory)) {
+            // Message is sent in a report-channel -> sync to thread
+            const threads = await (message.channel as TextChannel).threads.fetch();
+
+            if (threads) {
+                const thread = threads.threads.first();
+
+                let attachments = [];
+
+                if (message.attachments?.size > 0) {
+                    for (const [_, attachment] of message.attachments) {
+                        attachments.push(attachment);
+                    }
+                }
+
+                const messageContent = `${message.author.displayName}: ${message.content}`;
+                await thread?.send(attachments.length > 0 ? { content: messageContent, files: attachments } : { content: messageContent });
+            }
+        } else if ((message.channel.parent?.parentId === client.channelIds.ticketCategory || message.channel.parent?.parentId === client.channelIds.wipTicketCategory)) {
+            // Message is sent in a report-channel-thread -> sync to channel
+            const channel = message.channel.parent as TextChannel;
+            let attachments = [];
+
+            if (message.attachments?.size > 0) {
+                for (const [_, attachment] of message.attachments) {
+                    attachments.push(attachment);
+                }
+            }
+
+            await channel.send(attachments.length > 0 ? { content: message.content, files: attachments } : { content: message.content });
+        }
     }
 
     //#endregion

--- a/src/modules/TicketHandler.ts
+++ b/src/modules/TicketHandler.ts
@@ -1776,11 +1776,19 @@ export default class TicketHandler {
             const embed = new EmbedBuilder()
                 .setTitle(`${ticketType === 'trialteam' ? 'Trial Team' : ticketType === 'lorebook' ? 'Lore Book Crew' : ticketType === 'lorebookkill' ? 'Lore Book Kill' : capitalizeFirstLetter(ticketType)} Ticket`)
                 .setColor(this.client.color)
-                .setTimestamp()
-                .setAuthor({
+                .setTimestamp();
+
+            if (ticketType === 'clearance') {
+                embed.setAuthor({
+                    name: `User: ${this.client.user?.username}`,
+                    iconURL: this.client.user?.displayAvatarURL()
+                });
+            } else {
+                embed.setAuthor({
                     name: `User: ${channel.guild.members.cache.get(userId)?.user.username || 'Unknown User'}`,
                     iconURL: channel.guild.members.cache.get(userId)?.user.displayAvatarURL() || undefined
                 });
+            }
 
             let urls: string[] = [];
             const urlRegex = /(https?:\/\/[^\s]+|www\.[^\s]+)/g;

--- a/src/modules/TranscriptGenerator.ts
+++ b/src/modules/TranscriptGenerator.ts
@@ -1,14 +1,18 @@
 import { Collection, Message, PartialMessage, Attachment } from 'discord.js';
+import Bot from '../Bot';
 
 export default class TranscriptGenerator {
-
-    public static async createTranscript(messages: Collection<string, Message | PartialMessage>, channelName: string): Promise<Buffer> {
-        const html = await this.generateHtml(messages, channelName);
+    public static async createTranscript(messages: Collection<string, Message | PartialMessage>, channelName: string, client: Bot): Promise<Buffer> {
+        const html = await this.generateHtml(messages, channelName, client);
         return Buffer.from(html, 'utf-8');
     }
 
-    private static async generateHtml(messages: Collection<string, Message | PartialMessage>, channelName: string): Promise<string> {
-        const messageHtml = Array.from(messages.values()).reverse().map(this.formatMessage, this).join('');
+    private static async generateHtml(messages: Collection<string, Message | PartialMessage>, channelName: string, client: Bot): Promise<string> {
+        let messageHtml: string = '';
+
+        for (const message of Array.from(messages.values())) {
+            messageHtml += await this.formatMessage(message, client);
+        }
 
         return `
             <!DOCTYPE html>
@@ -106,6 +110,11 @@ export default class TranscriptGenerator {
                             color: #72767d;
                             margin-top: 10px;
                         }
+                        .embed-img {
+                            max-width: 400px;
+                            border-radius: 3px;
+                            margin-top: 5px;
+                        }
                     </style>
                 </head>
                 <body>
@@ -120,7 +129,7 @@ export default class TranscriptGenerator {
         `;
     }
 
-    private static formatMessage(message: Message | PartialMessage): string {
+    private static async formatMessage(message: Message | PartialMessage, client: Bot): Promise<string> {
         const author = message.author;
         // This can be null for partial messages
         if (!author) {
@@ -147,16 +156,16 @@ export default class TranscriptGenerator {
 
         // Handle attachments
         if (message.attachments.size > 0) {
-            message.attachments.forEach(attachment => {
-                messageBody += this.formatAttachment(attachment);
-            });
+            for (const [_, attachment] of message.attachments) {
+                messageBody += await this.formatAttachment(attachment, client);
+            }
         }
 
         // Handle embeds
         if (message.embeds.length > 0) {
-            message.embeds.forEach(embed => {
-                messageBody += this.formatEmbed(embed);
-            });
+            for (const embed of message.embeds) {
+                messageBody += await this.formatEmbed(embed, client);
+            }
         }
 
         return `
@@ -173,15 +182,16 @@ export default class TranscriptGenerator {
         `;
     }
 
-    private static formatAttachment(attachment: Attachment): string {
+    private static async formatAttachment(attachment: Attachment, client: Bot): Promise<string> {
         const isImage = attachment.contentType?.startsWith('image/');
         if (isImage) {
-            return `<div class="attachment"><a href="${attachment.url}" target="_blank">${this.escapeHtml(attachment.name || 'attachment')}</a><br><img src="${attachment.url}" alt="Attachment Image"></div>`;
+            const newUrl: string = await client.util.reuploadImage(attachment.url);
+            return `<div class="attachment"><a href="${newUrl}" target="_blank">${this.escapeHtml(attachment.name || 'attachment')}</a><br><img src="${newUrl}" alt="Attachment Image"></div>`;
         }
         return `<div class="attachment"><a href="${attachment.url}" target="_blank">Download ${this.escapeHtml(attachment.name || 'attachment')}</a></div>`;
     }
 
-    private static formatEmbed(embed: any): string {
+    private static async formatEmbed(embed: any, client: Bot): Promise<string> {
         let embedHtml = '<div class="embed">';
         if (embed.title) {
             embedHtml += `<div class="embed-title">${this.escapeHtml(embed.title)}</div>`;
@@ -191,6 +201,10 @@ export default class TranscriptGenerator {
         }
         if (embed.footer?.text) {
             embedHtml += `<div class="embed-footer">${this.escapeHtml(embed.footer.text)}</div>`;
+        }
+        if (embed.data?.type === 'image') {
+            const newUrl: string = await client.util.reuploadImage(embed.data.url);
+            embedHtml += `<div class="embed-img"><a href="${newUrl}" target="_blank">image</a><br><img src="${newUrl}" alt="Embedded Image"></div>`;
         }
         embedHtml += '</div>';
         return embedHtml;

--- a/src/modules/UtilityHandler.ts
+++ b/src/modules/UtilityHandler.ts
@@ -1,9 +1,10 @@
-import { EmbedBuilder, ChatInputCommandInteraction, Interaction, AttachmentBuilder, TextChannel, GuildMember, Message, Collection, FetchMessagesOptions } from 'discord.js';
+import { EmbedBuilder, ChatInputCommandInteraction, Interaction, AttachmentBuilder, TextChannel, GuildMember, Message, Collection, FetchMessagesOptions, User, ContainerBuilder } from 'discord.js';
 import Bot from '../Bot';
 import * as config from '../../config.json';
 import { Override } from '../entity/Override';
 import axios from 'axios';
 import { Timeout } from '../entity/Timeout';
+import { Warning } from '../entity/Warning';
 
 export default interface UtilityHandler {
     client: Bot;
@@ -341,6 +342,84 @@ export default class UtilityHandler {
             return true;
         } catch (error) {
             return false;
+        }
+    }
+
+    //#endregion
+
+    //#region Warnings
+
+    public async GetWarnings(user: User | null = null, id: number | null = null, reportRef: TextChannel | null = null): Promise<ContainerBuilder> {
+        // List warnings
+        const repository = this.client.dataSource.getRepository(Warning);
+        let foundWarnings: Warning[] | null = await repository.find({
+            order: {
+                createdAt: 'ASC'
+            }
+        });
+        let filters: string = '';
+
+        if (id) {
+            foundWarnings = foundWarnings.filter(x => x.id === id);
+            filters += `\n- **ID:** \`${id}\``;
+        }
+
+        if (user) {
+            foundWarnings = foundWarnings.filter(x => x.user === user.id);
+            filters += `\n- **User:** <@${user.id}>`;
+        }
+
+        if (reportRef) {
+            foundWarnings = foundWarnings.filter(x => x.reportRef === reportRef.id);
+            filters += `\n- **Report reference:** \`${reportRef}\``;
+        }
+
+        if (foundWarnings.length > 0 && foundWarnings.length < 25) {
+            const response = this.client.cv2.getContainerBuilder(null, `List warnings - \`${foundWarnings.length}\` found`);
+
+            let content: string = '';
+
+            if (id) {
+                content = `Found warning for ID \`${id}\`:\n\n`
+            } else if (user) {
+                content = `Found warnings for User <@${user.id}>:\n\n`
+            } else if (reportRef) {
+                content = `Found warnings for report reference \`${reportRef}\`:\n\n`
+            } else {
+                content = `Found warnings:\n\n`
+            }
+
+            for (const warning of foundWarnings) {
+                if (id) {
+                    content += `**User:** <@${warning.user}>\n`
+                    content += `**Reason:** \`${warning.reason}\`\n`;
+                    if (warning.reportRef) content += `**Report reference:** <#${warning.reportRef}>\n`;
+                } else if (user) {
+                    content += `**ID:** \`${warning.id}\`\n`;
+                    content += `**Reason:** \`${warning.reason}\`\n`;
+                    if (warning.reportRef) content += `**Report reference:** <#${warning.reportRef}>\n`;
+                } else {
+                    content += `**ID:** \`${warning.id}\`\n`;
+                    content += `**User:** <@${warning.user}>\n`;
+                    content += `**Reason:** \`${warning.reason}\`\n`;
+                    if (warning.reportRef) content += `**Report reference:** <#${warning.reportRef}>\n`;
+                }
+                content += '\n';
+            }
+
+            content = content.trim();
+
+            response.addTextDisplayComponents(builder => builder.setContent(content));
+
+            return response;
+        } else if (foundWarnings.length >= 25) {
+            const response = this.client.cv2.getContainerBuilder(false, 'List warnings')
+                .addTextDisplayComponents(builder => builder.setContent(`Found too many warnings (\`${foundWarnings.length}\`), please specify your search until a proper pagination system is implemented.`));
+            return response;
+        } else {
+            const response = this.client.cv2.getContainerBuilder(false, 'List warnings')
+                .addTextDisplayComponents(builder => builder.setContent(`Could not find any warnings for the specified filters:${filters.length > 0 ? filters : '\n- No filters provided'}`));
+            return response;
         }
     }
 


### PR DESCRIPTION
- updated discord.js
- new database table for host-participations
- renamed librarian to lorebook
- syncing messages in reports and clearance-tickets between a private thread and the ticket-main-channel itself to talk anonymous
- give-points and remove-points-commands are now able to give points to learner hours, librarians, trials for either participation, hosting or both
- new bot_owner-command "query" for alex and me
- slash-commands for lorebook crew: finish-lorebook, host-lorebook and lorebook-leaderboard
- slash-commands for teaching: finish-learner, host-learner and teacher-leaderboard
- slash-commands for trials: finish-trial, host-trial and trial-leaderboard
- reworked some image media handling to reupload via god-image-storage first so it doesn't get lost on deletion (ticket-archives and custom automod)
- reworked some transcript-generation for tickets: they are no longer upside down and show properly images posted in the image
- permission levels for teacher, lorebook and trial team in bot commands
- leaderboards show now all entries, not only the first 10
- ticket changes:
  - reports have now a user-select who they are reporting and an optional image upload for evidence
  - learner tickets have now a select where they can pick which mode/enrage they wanna learn, it is becomming automatically part of the channel name
  - teacher tickets have now a select where they can pick which mode/enrage they wanna teach
  - trial team ticketrs have now a select where they can pick which enrage they wanna trial ppl in
  - preset and kc in teacher and trial team tickets are now image uploads directly
  - teachers are automatically added to lorebook tickets and can see them aswell
  - report and clearance tickets check automatically for warnings of the reported user and let you know in the private thread
  - learner tickets have a new button for "quickfinish"
  - lorebook tickets have the same panel as learner tickets - but only for normal mode kills
- host card changes:
  - you can now pick any amount of learners/trialees/participants
  - you can now pick any amount of hosts
  - you can now assign multiple roles at once towards someone
  - variants for lorebook and trials also prepared
- "quickfinish" variant of hosts:
  - run by either a command /finish-{learner/lorebook/trial} or hitting the "finish an hour" button in the tickets
  - select all host, fillers, and participants in one go and write a summary
- finishing a host rewards points per learner / participant in lorebook/learner hosts
