### PR TITLE
Remove the elite500 trial role

### DIFF
--- a/src/GuildSpecifics.ts
+++ b/src/GuildSpecifics.ts
@@ -45,7 +45,6 @@ export function getChannels(guildId: string | undefined): Channels {
             trialLounge: '1405664850469847122',
             autoBanLogs: '1450965697378386115',
             trialeeTicketsCategory: '1412871767932010547',
-            trialee500TicketsCategory: '1412871767932010547',
             trialee1000TicketsCategory: '1412871767932010547',
             trialee2000TicketsCategory: '1412871767932010547',
             vouchTicketsCategory: `1464678728410992844`,
@@ -104,7 +103,6 @@ export function getChannels(guildId: string | undefined): Channels {
             teachersChat: '1404510586536202453',
 
             // trialee tickets
-            trialee500TicketsCategory: '1464336828206415923',
             trialee1000TicketsCategory: '1483844686467563530',
             trialee2000TicketsCategory: '1483844787357614210',
             masterTrialee1000TicketsCategory: '1491863628649861220',
@@ -190,10 +188,8 @@ export function getRoles(guildId: string | undefined, stripRole: boolean = false
             elite: '1464337843651608696',
             elite2000: '1464337925524160738',
             elite1000: '1464337906159190016',
-            elite500: '1464337875503022135',
             elite2000trialee: '1468296795879772183',
             elite1000trialee: '1468296820319981568',
-            elite500trialee: '1468296846488375472',
 
             master: '1492215560652591124',
             master2000: '1492215768388210749',
@@ -204,7 +200,6 @@ export function getRoles(guildId: string | undefined, stripRole: boolean = false
             // Notify Roles
             notifyElite2000: '1492216554279141387',
             notifyElite1000: '1492216530174218485',
-            notifyElite500: '1492216496045166744',
             notifyMaster2000: '1492215943340757154',
             notifyMaster1000: '1492215963758756062',
 
@@ -281,10 +276,8 @@ export function getRoles(guildId: string | undefined, stripRole: boolean = false
             elite: '1462534403589800200',
             elite2000: '1462529648326869184',
             elite1000: '1462529561551175844',
-            elite500: '1462529277198205216',
             elite2000trialee: '1468293818884558981',
             elite1000trialee: '1468293781513175082',
-            elite500trialee: '1468293751461122303',
 
             master: '1485117983046238220',
             master2000: '1489788387870380202',
@@ -295,7 +288,6 @@ export function getRoles(guildId: string | undefined, stripRole: boolean = false
             // Notify Roles
             notifyElite2000: '1462531083135357031',
             notifyElite1000: '1462531053230227699',
-            notifyElite500: '1462531007382028288',
             notifyMaster2000: '1489811960479613049',
             notifyMaster1000: '1489811866552107058',
 

--- a/src/interactions/role-management/AssignMatchmaking.ts
+++ b/src/interactions/role-management/AssignMatchmaking.ts
@@ -27,7 +27,6 @@ export default class AssignMatchmaking extends BotInteraction {
         if (focusedOption.name !== 'role') return;
 
         const options = {
-            'Elite 500': 'elite500',
             'Elite 1000': 'elite1000',
             'Elite 2000': 'elite2000',
             'Master 1000': 'master1000',

--- a/src/interactions/trialteam/VouchUser.ts
+++ b/src/interactions/trialteam/VouchUser.ts
@@ -24,7 +24,6 @@ export default class VouchUser extends BotInteraction {
             .addUserOption(option => option.setName('user').setDescription('User to vouch for').setRequired(true))
             .addStringOption(option => option.setName('role').setDescription('Elite role').setRequired(true)
                 .addChoices(
-                    { name: 'Elite 500', value: 'elite500' },
                     { name: 'Elite 1000', value: 'elite1000' },
                     { name: 'Elite 2000', value: 'elite2000' }
                 ))

--- a/src/modules/HostHandler.ts
+++ b/src/modules/HostHandler.ts
@@ -799,15 +799,13 @@ export default class HostHandler {
             return null;
         }
 
-        return /^(elite500|elite1000|elite2000|master1000|master2000)$/.test(normalizedRoleKey)
+        return /^(elite1000|elite2000|master1000|master2000)$/.test(normalizedRoleKey)
             ? normalizedRoleKey
             : null;
     }
 
     private static trialRoleKeyToLabel(roleKey: string): string {
         switch (roleKey) {
-            case 'elite500':
-                return 'Elite 500';
             case 'elite1000':
                 return 'Elite 1000';
             case 'elite2000':

--- a/src/modules/TicketHandler.ts
+++ b/src/modules/TicketHandler.ts
@@ -636,7 +636,6 @@ export default class TicketHandler {
         const tierSelect = new StringSelectMenuBuilder()
             .setCustomId('tier')
             .addOptions([
-                new StringSelectMenuOptionBuilder().setLabel('Elite - 500% Enrage').setValue('elite500'),
                 new StringSelectMenuOptionBuilder().setLabel('Elite - 1000% Enrage').setValue('elite1000'),
                 new StringSelectMenuOptionBuilder().setLabel('Elite - 2000% Enrage').setValue('elite2000'),
 
@@ -1883,9 +1882,6 @@ export default class TicketHandler {
                     break;
                 case 'trialee':
                     switch (formData?.tier) {
-                        case 'elite500':
-                            parentCategoryId = this.client.channelIds.trialee500TicketsCategory;
-                            break;
                         case 'elite1000':
                             parentCategoryId = this.client.channelIds.trialee1000TicketsCategory;
                             break;
@@ -2031,10 +2027,6 @@ export default class TicketHandler {
 
                 // give user the notify role for trialees
                 switch (formData.tier) {
-                    case 'elite500':
-                        await member.roles.add(this.client.roleIds.elite500trialee).catch(() => { });
-                        break;
-
                     case 'elite1000':
                         await member.roles.add(this.client.roleIds.elite1000trialee).catch(() => { });
                         break;

--- a/src/modules/UtilityHandler.ts
+++ b/src/modules/UtilityHandler.ts
@@ -119,12 +119,11 @@ export default class UtilityHandler {
     }
 
     get trialTierOrder(): string[] {
-        return ['elite500', 'elite1000', 'elite2000', 'master1000', 'master2000'];
+        return ['elite1000', 'elite2000', 'master1000', 'master2000'];
     }
 
     get trialTierPriorities(): RolePriorityMap {
         return {
-            elite500: 1,
             elite1000: 2,
             elite2000: 3,
             master1000: 3,
@@ -134,7 +133,6 @@ export default class UtilityHandler {
 
     get trialNotifyRoles(): RoleMap {
         return {
-            elite500: 'notifyElite500',
             elite1000: 'notifyElite1000',
             elite2000: 'notifyElite2000',
             master1000: 'notifyMaster1000',
@@ -144,7 +142,6 @@ export default class UtilityHandler {
 
     get trialeeRoles(): RoleMap {
         return {
-            elite500: 'elite500trialee',
             elite1000: 'elite1000trialee',
             elite2000: 'elite2000trialee',
             master1000: 'master1000trialee',
@@ -267,8 +264,6 @@ export default class UtilityHandler {
         }
 
         switch (fallbackEnrage) {
-            case '500':
-                return 'elite500';
             case '1000':
                 return 'elite1000';
             case '2000':


### PR DESCRIPTION
Retire the "Elite 500" / "Elite - 500% Enrage" trial tier from the bot. Removes every way to trial for it (application ticket option, trialee role, ticket category routing), assign it (/vouch and /assign-matchmaking options), and ping it (notifyElite500 role). The 500% enrage auto-award fallback is dropped so a 500% enrage no longer grants a trial role, and the now-dead role/channel IDs are deleted from GuildSpecifics.