### PR TITLE
docs: document local setup (.env + config.json)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,27 @@
+# Copy this file to `.env` and fill in real values. The `.env` file is gitignored.
+
+# --- Required to boot ---
+# Your Discord bot token (Developer Portal > Bot > Reset Token).
+TOKEN=
+# Free-form environment label, e.g. development | production.
+ENVIRONMENT=development
+
+# --- Required for guild features (role/channel maps in src/GuildSpecifics.ts) ---
+# MAIN guild = 885457551397912596 — the only guild map containing trialee-chat and the
+# scheduled-trial reminder/ping targets. Any other id falls back to test-server behavior.
+GUILD_ID=
+
+# --- Optional (only needed if the corresponding feature is used) ---
+# Sharding / logging
+CLUSTER_ID=
+ERROR_WEBHOOK_URL=
+INFO_WEBHOOK_URL=
+# Google Sheets API (service account)
+GOOGLE_PROJECT_ID=
+GOOGLE_PRIVATE_KEY_ID=
+GOOGLE_PRIVATE_KEY=
+GOOGLE_CLIENT_EMAIL=
+GOOGLE_CLIENT_ID=
+# Twitch integration
+TWITCH_CLIENT_ID=
+TWITCH_CLIENT_SECRET=

--- a/README.md
+++ b/README.md
@@ -7,16 +7,42 @@ A project for Amascut Discord staff.
 ## Installation / Running the Bot
 
 1. `npm install`
-2. Set up a `config.json` with webhooks and overriden `OWNER` permissions.
-3. Set your development TOKEN variable in `.env`.
-4. Set your environment ENVIRONMENT variable in `.env`.
+2. Create `config.json` in the repo root — copy `config.example.json` and fill it in (see [Configuration](#configuration)).
+3. Create `.env` in the repo root — copy `.env.example` and set at least `TOKEN`, `ENVIRONMENT`, and `GUILD_ID`.
+
+Both `config.json` and `.env` are gitignored (they hold secrets / per-deployment values), so each environment provides its own.
 
 ### Getting Started
 
 ```shell
 npm install
+cp config.example.json config.json   # then edit
+cp .env.example .env                  # then edit
 npm run start
 ```
+
+## Configuration
+
+### `.env`
+
+| Variable | Required | Purpose |
+| --- | --- | --- |
+| `TOKEN` | yes | Discord bot token. Boot throws `Token Missing` without it. |
+| `ENVIRONMENT` | yes | Free-form label (e.g. `development` / `production`). Boot throws `Environment Missing` without it. |
+| `GUILD_ID` | for guild features | Selects the role/channel maps in `src/GuildSpecifics.ts`. The MAIN guild (`885457551397912596`) is the only map with trialee-chat and the scheduled-trial reminder/ping targets; any other id falls back to test-server behavior. |
+| `CLUSTER_ID`, `ERROR_WEBHOOK_URL`, `INFO_WEBHOOK_URL`, `GOOGLE_*`, `TWITCH_*` | optional | Only needed if you exercise the corresponding feature (sharding/logging, Google Sheets, Twitch). |
+
+### `config.json`
+
+Lives at the repo root. Shape (see `config.example.json`):
+
+| Key | Type | Purpose |
+| --- | --- | --- |
+| `colours` | `{ green, red, blue }` (color ints) | Embed / Components V2 accent colors. |
+| `owners` | `string[]` (user IDs) | Owner-gated commands (`OWNER` permission). Add your Discord user ID. |
+| `kph` | `number` | Kills/hour used by the boss-revenue GP/hour calc. |
+| `guildMessageDisabled` | `string[]` (guild IDs) | Guilds where message handling is disabled. |
+| `lastChannelId` / `lastMessageId` | `string` | BossRevenueV2 refresh target; leave empty to skip. |
 
 ### Acknowledgements
 

--- a/config.example.json
+++ b/config.example.json
@@ -1,0 +1,12 @@
+{
+    "colours": {
+        "green": 5763719,
+        "red": 15548997,
+        "blue": 5793266
+    },
+    "owners": ["YOUR_DISCORD_USER_ID"],
+    "kph": 30,
+    "guildMessageDisabled": [],
+    "lastChannelId": "",
+    "lastMessageId": ""
+}


### PR DESCRIPTION
## What

A fresh checkout cannot boot the bot: there's no documentation of the two required, gitignored files at the repo root. The bot crashes first with `Cannot find module '../../config.json'`, then (once that exists) `Token Missing`.

This PR makes local setup self-serve:

- **`config.example.json`** — committable template for the gitignored `config.json` (root). Documents the real runtime shape the code reads: `colours.{green,red,blue}`, `owners`, `kph`, `guildMessageDisabled`, `lastChannelId`, `lastMessageId`.
- **`.env.example`** — committable template for the gitignored `.env`. Marks `TOKEN` / `ENVIRONMENT` as boot-required and `GUILD_ID` as required for guild features, with the rest grouped as optional-per-feature.
- **README** — adds a Configuration section documenting both files, plus `cp` steps in Getting Started. Notes that `GUILD_ID=885457551397912596` (MAIN) is the only guild map with trialee-chat / scheduled-trial targets; other ids fall back to test-server behavior.

## Notes

- No code changes; `config.json` and `.env` remain gitignored.
- Discovered while delivering the trial base-signup feature (#197), kept on a separate branch to keep that PR scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)