### PR TITLE
feat(report): revoke an already-approved trial report

### DIFF
--- a/src/entity/TrialReport.ts
+++ b/src/entity/TrialReport.ts
@@ -30,6 +30,9 @@ export class TrialReport {
     @Column({ default: 'pending' })
     status: string
 
+    @Column({ type: 'text', nullable: true })
+    messageId: string | null
+
     @CreateDateColumn({ name: 'created_at'})
     createdAt: Date
 }

--- a/src/modules/ButtonHandler.ts
+++ b/src/modules/ButtonHandler.ts
@@ -65,9 +65,9 @@ export default class ButtonHandler {
             this.rejectRoleAssign(interaction, id.substring('rejectRoleAssign_'.length));
             return;
         }
-        if (id.startsWith('report_approve') || id.startsWith('report_reject')) {
-        new ReportHandler(this.client, interaction.customId, interaction);
-        return;
+        if (id.startsWith('report_approve') || id.startsWith('report_reject') || id.startsWith('report_revoke')) {
+            new ReportHandler(this.client, interaction.customId, interaction);
+            return;
         }
 
         switch (id) {

--- a/src/modules/ReportHandler.ts
+++ b/src/modules/ReportHandler.ts
@@ -1,4 +1,4 @@
-import { ActionRowBuilder, ButtonBuilder, ButtonInteraction, ButtonStyle, ChatInputCommandInteraction, EmbedBuilder, FileUploadBuilder, Interaction, Message, MessageFlags, ModalBuilder, ModalSubmitInteraction, RoleSelectMenuBuilder, StringSelectMenuBuilder, StringSelectMenuOptionBuilder, TextChannel, TextInputBuilder, TextInputStyle, UserSelectMenuBuilder } from 'discord.js';
+import { ActionRowBuilder, ButtonBuilder, ButtonInteraction, ButtonStyle, ChatInputCommandInteraction, EmbedBuilder, FileUploadBuilder, Interaction, MessageFlags, ModalBuilder, ModalSubmitInteraction, StringSelectMenuBuilder, StringSelectMenuOptionBuilder, TextChannel, TextInputBuilder, TextInputStyle, UserSelectMenuBuilder } from 'discord.js';
 import Bot from '../Bot';
 import { TrialReport } from '../entity/TrialReport';
 import { ReportBlacklist } from '../entity/ReportBlacklist';

--- a/src/modules/ReportHandler.ts
+++ b/src/modules/ReportHandler.ts
@@ -417,19 +417,24 @@ private async approveReport(interaction: ButtonInteraction<'cached'>) {
             }
         }
 
-        // Update embed
-        const revokeRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
-            new ButtonBuilder()
-                .setCustomId('report_revoke')
-                .setLabel('Revoke')
-                .setStyle(ButtonStyle.Secondary)
-        );
+        // Update embed. If this approval triggered the role removal, the report row was
+        // flipped to 'role_removed' and the report is no longer revocable, so render no
+        // Revoke button. Only show Revoke while the row remains 'approved'.
+        const roleWasRemoved = allApprovedReports.length >= reportHandler.REQUIRED_REPORTS;
+        const components = roleWasRemoved
+            ? []
+            : [new ActionRowBuilder<ButtonBuilder>().addComponents(
+                new ButtonBuilder()
+                    .setCustomId('report_revoke')
+                    .setLabel('Revoke')
+                    .setStyle(ButtonStyle.Secondary)
+            )];
 
         await interaction.message.edit({
             embeds: [EmbedBuilder.from(embed)
                 .setColor(0x00ff00)
                 .setTitle('Report - APPROVED')],
-            components: [revokeRow]
+            components
         });
 
         await interaction.followUp({ content: `Report approved! (${allApprovedReports.length}/${reportHandler.REQUIRED_REPORTS})`, flags: MessageFlags.Ephemeral });

--- a/src/modules/ReportHandler.ts
+++ b/src/modules/ReportHandler.ts
@@ -39,6 +39,12 @@ export default class reportHandler {
             return;
         }
 
+        // Revoke an already-approved report
+        if (id === 'report_revoke' && interaction.isButton()) {
+            this.revokeReport(interaction as ButtonInteraction<'cached'>);
+            return;
+        }
+
         if (id === 'checkreports_submit' && interaction.isChatInputCommand()) {
         this.showCheckReportsModal(interaction as ChatInputCommandInteraction<'cached'>);
         return;
@@ -280,7 +286,8 @@ private async approveReport(interaction: ButtonInteraction<'cached'>) {
             role: roleKey,
             description: description,
             status: 'approved',
-            ticketChannelId: interaction.channel!.id
+            ticketChannelId: interaction.channel!.id,
+            messageId: interaction.message.id
         });
         await reportRepository.save(report);
 
@@ -411,11 +418,18 @@ private async approveReport(interaction: ButtonInteraction<'cached'>) {
         }
 
         // Update embed
+        const revokeRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
+            new ButtonBuilder()
+                .setCustomId('report_revoke')
+                .setLabel('Revoke')
+                .setStyle(ButtonStyle.Secondary)
+        );
+
         await interaction.message.edit({
             embeds: [EmbedBuilder.from(embed)
                 .setColor(0x00ff00)
                 .setTitle('Report - APPROVED')],
-            components: []
+            components: [revokeRow]
         });
 
         await interaction.followUp({ content: `Report approved! (${allApprovedReports.length}/${reportHandler.REQUIRED_REPORTS})`, flags: MessageFlags.Ephemeral });
@@ -449,6 +463,99 @@ private async rejectReport(interaction: ButtonInteraction<'cached'>) {
         await interaction.followUp({ content: 'Report rejected.', flags: MessageFlags.Ephemeral });
     } catch (error) {
         this.client.logger.error({ message: 'Failed to reject report', error, handler: this.constructor.name });
+    }
+}
+
+private async revokeReport(interaction: ButtonInteraction<'cached'>) {
+    // Permission gate FIRST - before any defer or state change.
+    if (!await this.client.util.hasRolePermissions(this.client, ['admin', 'owner'], interaction)) {
+        this.client.logger.log(
+            {
+                message: `Attempted restricted permissions. { command: Revoke Report, user: ${interaction.user.username}, channel: ${interaction.channel} }`,
+                handler: this.constructor.name,
+            },
+            true
+        );
+        return await interaction.reply({
+            content: 'Only admin/owner can revoke.',
+            flags: MessageFlags.Ephemeral
+        });
+    }
+
+    await interaction.deferUpdate();
+
+    try {
+        const reportRepository = this.client.dataSource.getRepository(TrialReport);
+        const report = await reportRepository.findOne({ where: { messageId: interaction.message.id } });
+
+        if (!report) {
+            return await interaction.followUp({
+                content: 'No matching report record was found for this message, so it cannot be revoked.',
+                flags: MessageFlags.Ephemeral
+            });
+        }
+
+        if (report.status !== 'approved') {
+            return await interaction.followUp({
+                content: 'This report is not in an approved state and cannot be revoked.',
+                flags: MessageFlags.Ephemeral
+            });
+        }
+
+        // Authoritative step: persist the status flip BEFORE any UI/audit work.
+        report.status = 'revoked';
+        await reportRepository.save(report);
+
+        this.client.logger.log(
+            {
+                message: `Report #${report.id} revoked by ${interaction.user.username} (${interaction.user.id}). Reported user: ${report.reportedUser}, role: ${report.role}.`,
+                handler: this.constructor.name,
+            },
+            true
+        );
+
+        // Re-render the original approved message to a revoked visual state.
+        const originalEmbed = interaction.message.embeds[0];
+        if (originalEmbed) {
+            await interaction.message.edit({
+                embeds: [EmbedBuilder.from(originalEmbed)
+                    .setColor(0x808080)
+                    .setTitle('Report - REVOKED')],
+                components: []
+            }).catch((error) => {
+                this.client.logger.error({ message: 'Failed to re-render revoked report message', error, handler: this.constructor.name });
+            });
+        }
+
+        // Audit log - guarded so an unconfigured/unfetchable channel cannot abort the revoke.
+        try {
+            const logChannel = this.client.channelIds.roleAssignLogs
+                ? await this.client.channels.fetch(this.client.channelIds.roleAssignLogs) as TextChannel : null;
+
+            if (logChannel) {
+                await logChannel.send({
+                    embeds: [new EmbedBuilder()
+                        .setColor(0x808080)
+                        .setTitle('Report Revoked')
+                        .setDescription(`An approved report against <@${report.reportedUser}> for the role ${this.client.roles[report.role]} has been revoked by <@${interaction.user.id}>.`)
+                        .addFields(
+                            { name: 'Reported User', value: `<@${report.reportedUser}>` },
+                            { name: 'Role', value: `${this.client.roles[report.role]}` },
+                            { name: 'RSN', value: `${report.rsn}` },
+                            { name: 'Reporter', value: `<@${report.reporter}>` },
+                            { name: 'Revoked By', value: `<@${interaction.user.id}>` }
+                        )
+                        .setTimestamp()]
+                });
+            }
+        } catch (auditError) {
+            this.client.logger.error({ message: 'Failed to post revoke audit log', error: auditError, handler: this.constructor.name });
+        }
+
+        await interaction.followUp({ content: 'Report revoked.', flags: MessageFlags.Ephemeral });
+    } catch (error) {
+        this.client.logger.error({ message: 'Failed to revoke report', error, handler: this.constructor.name });
+        await interaction.followUp({ content: 'Error revoking report.', flags: MessageFlags.Ephemeral }).catch(() => { });
     }
 }
 


### PR DESCRIPTION
## Summary

Adds the ability to revoke a single already-approved trial report. A **Revoke** button now appears on approved report messages; clicking it (as admin/owner) flips that one `TrialReport` row to a terminal `'revoked'` status so it no longer counts toward the approved total or the 3-report role-removal threshold. No roles are restored or recomputed — even if the report participated in a completed 3-report removal.

## What changed

- **`src/entity/TrialReport.ts`** — added nullable `messageId` column (matching existing nullable id-column style; safe under `synchronize: true`).
- **`src/modules/ReportHandler.ts`** — persist `interaction.message.id` as `messageId` on approval; render a single Revoke button (`report_revoke`) on the approved message; add `report_revoke` constructor route and the `revokeReport` method.
- **`src/modules/ButtonHandler.ts`** — route `report_revoke` to `ReportHandler`; fixed the block's indentation to 4-space.

`revokeReport` enforces the permission gate before any defer/state change, persists the status flip before any UI/audit work, and wraps the message re-render and the `roleAssignLogs` audit post in their own try/catch so a deleted message or unconfigured channel cannot surface an error after the DB flip persisted.

## Acceptance criteria

- [x] AC1 — approved message displays a Revoke button
- [x] AC2 — non-admin/owner click is refused ephemerally with no DB/message change
- [x] AC3 — admin/owner revoke on an approved row flips status to `'revoked'` and persists
- [x] AC4 — message re-rendered "Report - REVOKED", grey (`0x808080`), no buttons
- [x] AC5 — revoked row excluded from `/checkreports` approved count (existing `status:'approved'` filter)
- [x] AC6 — non-`'approved'` report (revoked / role_removed) refused, no state change, no role re-grant
- [x] AC7 — no matching row (legacy null messageId) refused ephemerally, no state change
- [x] AC8 — logger entry + audit embed to `roleAssignLogs`; survives unconfigured/unfetchable channel
- [x] AC9 — gate is exactly `['admin','owner']`; approve/reject gates unchanged
- [x] AC10 — `npx tsc --noEmit` introduces zero new errors (5 pre-existing baseline errors unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)