### PR TITLE
feat(tickets): grant learner-ticket role on open, strip ticket roles on close

### DIFF
--- a/src/GuildSpecifics.ts
+++ b/src/GuildSpecifics.ts
@@ -177,6 +177,7 @@ export function getRoles(guildId: string | undefined, stripRole: boolean = false
             vouchTeam: '1484617729515323596',
             teacher: '1412871872374116463',
             helperLearner: '1412871872374116463',
+            learnerTicket: '1517933435140833352',
             lorebook: '1441892735144558776',
 
             CONTENT_CREATOR_ROLE: '1391860635456901393',
@@ -273,6 +274,7 @@ export function getRoles(guildId: string | undefined, stripRole: boolean = false
             vouchTeam: '1484617729515323596',
             teacher: '1412881470673916077',
             helperLearner: '1404509333185892422',
+            learnerTicket: '1517932957745287321',
             lorebook: '1405001670101827617',
             editor: '1389397640533250058',
 

--- a/src/modules/TicketHandler.ts
+++ b/src/modules/TicketHandler.ts
@@ -1107,6 +1107,8 @@ export default class TicketHandler {
 
             if (ticketUserId) {
                 await channel.permissionOverwrites.delete(ticketUserId);
+                // Strip ticket-scoped roles granted on open (learner-ticket / trialee role).
+                await this.removeTicketRoles(channel, ticketUserId);
             }
 
             const closedEmbed = new EmbedBuilder()
@@ -1189,6 +1191,53 @@ export default class TicketHandler {
         const userPermissions = channel.permissionOverwrites.cache.get(interaction.user.id);
 
         return userPermissions !== undefined;
+    }
+
+    /** Learner tickets live under the learner category and (unlike other types) have no name prefix. */
+    private isLearnerTicket(channel: TextChannel): boolean {
+        return channel.parentId === this.client.channelIds.learnerTicketsCategory;
+    }
+
+    /** Trial-application tickets are named `trialee-XXXX`. */
+    private isTrialeeTicket(channel: TextChannel): boolean {
+        return channel.name.startsWith('trialee');
+    }
+
+    /**
+     * Strip the roles that were granted for the lifetime of a ticket: the learner-ticket role on
+     * learner tickets, and whichever per-tier trialee role the member still holds on trial-application
+     * tickets. Best-effort — a member who has left the guild or a missing/sentinel role id is skipped.
+     */
+    private async removeTicketRoles(channel: TextChannel, userId: string): Promise<void> {
+        let member: GuildMember;
+        try {
+            member = await channel.guild.members.fetch(userId);
+        } catch {
+            return; // member left the guild — nothing to strip
+        }
+
+        const sentinel = '000000000000000000';
+        const roleIds: string[] = [];
+
+        if (this.isLearnerTicket(channel)) {
+            const learnerTicketRoleId = this.client.roleIds.learnerTicket;
+            if (learnerTicketRoleId && learnerTicketRoleId !== sentinel) {
+                roleIds.push(learnerTicketRoleId);
+            }
+        }
+
+        if (this.isTrialeeTicket(channel)) {
+            for (const roleKey of Object.values(this.client.util.trialeeRoles)) {
+                const roleId = this.client.roleIds[roleKey];
+                if (roleId && roleId !== sentinel && member.roles.cache.has(roleId)) {
+                    roleIds.push(roleId);
+                }
+            }
+        }
+
+        if (roleIds.length > 0) {
+            await member.roles.remove(roleIds).catch(() => { });
+        }
     }
 
     //#endregion
@@ -1519,6 +1568,18 @@ export default class TicketHandler {
                 AttachFiles: true,
                 EmbedLinks: true
             });
+
+            // Re-grant the learner-ticket role stripped on close. (Trialee roles are intentionally
+            // not re-added: a passed trial has already swapped the trialee role for the earned tier.)
+            if (this.isLearnerTicket(channel)) {
+                const learnerTicketRoleId = this.client.roleIds.learnerTicket;
+                if (learnerTicketRoleId && learnerTicketRoleId !== '000000000000000000') {
+                    try {
+                        const member = await channel.guild.members.fetch(ticketUserId);
+                        await member.roles.add(learnerTicketRoleId).catch(() => { });
+                    } catch { /* member left the guild */ }
+                }
+            }
 
             // Find and delete the support team controls message
             const controlsMessage = messages.find(msg =>
@@ -2059,6 +2120,12 @@ export default class TicketHandler {
                         ManageChannels: true,
                     }
                 );
+
+                // Grant the learner-ticket role for the lifetime of the ticket (removed on close).
+                const learnerTicketRoleId = this.client.roleIds.learnerTicket;
+                if (learnerTicketRoleId && learnerTicketRoleId !== '000000000000000000') {
+                    await member.roles.add(learnerTicketRoleId).catch(() => { });
+                }
             }
 
             if (ticketType === 'lorebookkill') {


### PR DESCRIPTION
## What
- Adds a new `learnerTicket` role to both guild maps in `GuildSpecifics.ts` (main `1517932957745287321`, test `1517933435140833352`).
- **Learner tickets:** the opener is granted `learnerTicket` on ticket creation, the role is stripped when the ticket is closed, and re-granted on reopen.
- **Trial-application (trialee) tickets:** closing the ticket now strips the per-tier trialee role the member still holds, so it no longer lingers when an application is closed without a pass.

## Why
Previously, closing a ticket only removed the user's channel access — the trialee role stayed on the member indefinitely on fail/no-show/withdraw, and there was no role tracking learner-ticket participants.

## Notes for reviewers
- Ticket type is detected by parent category (learner) and `trialee-` name prefix (trialee), mirroring existing `canCloseTicket` logic.
- Trialee roles are intentionally **not** re-added on reopen: a passed trial already swaps the trialee role for the earned tier before close, so the close-strip is a no-op on that path and only fires on fail/no-show/withdraw.
- All role mutations guard against missing/`000000000000000000` sentinel ids and a member who has left the guild (`.catch()` + try/catch on fetch).

## Verification
`npx tsc --noEmit` introduces **zero** new errors. Note: `production` already has 3 pre-existing tsc errors (in `MessageCreate.ts`, `TrialReport.ts`, `LeaderboardHandler.ts`) unrelated to this change — confirmed identical on a clean stash of the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)