### PR TITLE
feat(info): add /dpm damage-per-minute calculator

### DIFF
--- a/src/interactions/info/Dpm.ts
+++ b/src/interactions/info/Dpm.ts
@@ -1,0 +1,46 @@
+import { SlashCommandBuilder, ChatInputCommandInteraction, EmbedBuilder } from 'discord.js';
+import BotInteraction from '../../types/BotInteraction';
+
+export default class Dpm extends BotInteraction {
+    get name() {
+        return 'dpm';
+    }
+
+    get description() {
+        return 'Calculate damage per minute from a damage total and a time in seconds.';
+    }
+
+    get slashData() {
+        return new SlashCommandBuilder()
+            .setName(this.name)
+            .setDescription(this.description)
+            .addNumberOption((option) => option.setName('damage').setDescription('Total damage dealt').setRequired(true).setMinValue(0))
+            .addNumberOption((option) => option.setName('time').setDescription('Kill time in seconds').setRequired(true).setMinValue(0));
+    }
+
+    async run(interaction: ChatInputCommandInteraction): Promise<void> {
+        await interaction.deferReply();
+
+        const damage: number = interaction.options.getNumber('damage', true);
+        const time: number = interaction.options.getNumber('time', true);
+
+        if (time <= 0) {
+            await interaction.editReply('Time must be greater than 0 seconds.');
+            return;
+        }
+
+        const dpm = (damage / time) * 60;
+
+        const embed = new EmbedBuilder()
+            .setColor(this.client.color ?? 10454367)
+            .setTitle('Damage Per Minute')
+            .addFields(
+                { name: 'Damage', value: damage.toLocaleString('en-US'), inline: true },
+                { name: 'Time', value: `${time.toLocaleString('en-US')}s`, inline: true },
+                { name: 'DPM', value: `${Math.round(dpm).toLocaleString('en-US')}`, inline: true }
+            )
+            .setTimestamp();
+
+        await interaction.editReply({ embeds: [embed] });
+    }
+}


### PR DESCRIPTION
## Summary
Adds a deliberately minimal, stateless `/dpm` slash command in the `info` category. Takes two required number options — `damage` and `time` (seconds) — and replies with an embed showing damage per minute computed as `damage / time * 60`. Auto-discovered by `InteractionHandler`; no manual registration.

This is a pure calculator: no team size, no combat style, no persistence, no leaderboard. It is explicitly unrelated to the pre-existing `src/entity/DpmSubmission.ts` screenshot/approval feature, which is untouched.

Only one file changed: `src/interactions/info/Dpm.ts`.

## Acceptance criteria
- [x] New `/dpm` class extends `BotInteraction` at `src/interactions/info/Dpm.ts`, auto-discovered (no manual registration)
- [x] Exactly two required number options: `damage` and `time`
- [x] Replies with DPM = `damage / time * 60` (e.g. `1000000 / 120 → 500000`)
- [x] `time <= 0` replies with a clear error and does not produce Infinity/NaN
- [x] Ungated/public — no `permissions` getter (mirrors Ping/BotStats)
- [x] `npx tsc --noEmit` adds zero new errors (3 pre-existing unrelated baseline errors remain)
- [x] No persistence — no `DpmSubmission`, `DataSource`, TypeORM, or external service
- [x] Style matches `.prettierrc` (4-space indent, single quotes, printWidth 200, always-parens arrows, final newline, no trailing whitespace)

## Notes
- DPM is rounded for display (`Math.round`) — intentional, reads cleaner in the embed.
- Baseline: clean `production` already has 3 unrelated tsc errors (`MessageCreate.ts`, `TrialReport.ts`, `LeaderboardHandler.ts`). This change introduces none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)